### PR TITLE
fix(save): disambiguate derived slugs to prevent silent overwrites

### DIFF
--- a/palinode/core/save.py
+++ b/palinode/core/save.py
@@ -266,6 +266,13 @@ def save_memory(
         slug = re.sub(r'[^a-z0-9]+', '-', content.split('\n')[0].lower()[:30]).strip('-')
         if not slug:
             slug = str(int(time.time()))
+        # Disambiguate derived slugs to prevent silent overwrites when two
+        # distinct memories share the same opening line (issue #129).
+        # Explicitly-passed slugs intentionally overwrite (documented idempotent
+        # update escape hatch).
+        _derived_slug = True
+    else:
+        _derived_slug = False
 
     # module-level map (shared with the description-eligibility predicate
     # so the writer and the count/worklist derive from one literal).
@@ -385,6 +392,51 @@ def save_memory(
         raise SaveValidationError(f"Security scan failed: {reason}")
 
     file_path = os.path.join(config.palinode_dir, category, f"{slug}.md")
+
+    # Derived-slug collision prevention (issue #129): when the slug was NOT
+    # explicitly provided, check whether the target path already exists with
+    # DIFFERENT content. If so, disambiguate by appending a hash of the full
+    # content. A byte-identical re-save is allowed through (idempotent).
+    if _derived_slug and os.path.exists(file_path):
+        try:
+            import frontmatter as _fm
+
+            with open(file_path, "r", encoding="utf-8") as _existing_f:
+                _existing_post = _fm.loads(_existing_f.read())
+            _existing_body = _existing_post.content
+            if _existing_body.strip() != content.strip():
+                # Different content → disambiguate with full-content hash
+                _content_hash_suffix = hashlib.sha256(
+                    content.encode()
+                ).hexdigest()[:8]
+                slug = f"{slug}-{_content_hash_suffix}"
+                file_path = os.path.join(
+                    config.palinode_dir, category, f"{slug}.md"
+                )
+                # Loop until the candidate is either unused or byte-identical
+                while os.path.exists(file_path):
+                    with open(file_path, "r", encoding="utf-8") as _check_f:
+                        _check_post = _fm.loads(_check_f.read())
+                    if _check_post.content.strip() == content.strip():
+                        break  # same content, allow re-save
+                    # Still colliding (astronomically unlikely with sha256[:8])
+                    _content_hash_suffix = hashlib.sha256(
+                        (content + _content_hash_suffix).encode()
+                    ).hexdigest()[:8]
+                    slug = f"{slug}-{_content_hash_suffix}"
+                    file_path = os.path.join(
+                        config.palinode_dir, category, f"{slug}.md"
+                    )
+        except (OSError, ValueError) as exc:
+            # Unreadable existing file: proceed with the original path
+            # (matches existing fail-open behaviour elsewhere in this function)
+            logger.warning(
+                "Could not read existing file for slug collision check %r (%s); "
+                "proceeding with original path",
+                file_path,
+                exc,
+            )
+
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
     content_hash = hashlib.sha256(content.encode()).hexdigest()

--- a/tests/test_save_slug_collision.py
+++ b/tests/test_save_slug_collision.py
@@ -1,0 +1,126 @@
+"""Tests for derived-slug collision prevention (issue #129).
+
+When ``slug`` is omitted, the save path derives one from the opening words
+of the content. Two saves whose openings agree used to resolve to the same
+file, silently overwriting the first. This test suite verifies that:
+
+1. Two saves sharing an opening line but differing afterwards produce two
+   distinct files, both retrievable.
+2. Two saves identical for the first 100 characters but differing after
+   character 100 still produce two distinct files (the prefix-hash trap).
+3. An explicitly-passed slug still overwrites (documented escape hatch).
+4. A re-save of identical content is idempotent (no spurious disambiguation).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+
+from palinode.core.config import config
+from palinode.core.save import save_memory
+
+
+@pytest.fixture
+def mock_palinode_dir(tmp_path, monkeypatch):
+    """Point palinode_dir (= memory_dir) at a temp directory for the test."""
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    monkeypatch.setattr(config.git, "auto_commit", False)
+    monkeypatch.setattr(config.git, "auto_push", False)
+    yield str(tmp_path)
+
+
+def _read_body(file_path: str) -> str:
+    """Read the markdown body (after frontmatter) from a memory file."""
+    with open(file_path, "r") as f:
+        text = f.read()
+    parts = text.split("---", 2)
+    if len(parts) >= 3:
+        return parts[2].strip()
+    return text.strip()
+
+
+class TestDerivedSlugCollision:
+    """Verify derived slugs disambiguate on content difference."""
+
+    def test_two_saves_shared_opening_produce_distinct_files(self, mock_palinode_dir):
+        """Two memories sharing an opening line but differing afterwards
+        must produce two distinct files, both retrievable."""
+        content_a = "User thanks that helps a lot\n\nALPHA — first memory with unique details"
+        content_b = "User thanks that helps a lot\n\nBRAVO — second memory with different details"
+
+        result_a = save_memory(content=content_a, type="Insight")
+        result_b = save_memory(content=content_b, type="Insight")
+
+        # They must produce different file paths
+        assert result_a["file_path"] != result_b["file_path"]
+        # Both files must exist
+        assert os.path.exists(result_a["file_path"])
+        assert os.path.exists(result_b["file_path"])
+        # Content must be preserved
+        assert "ALPHA" in _read_body(result_a["file_path"])
+        assert "BRAVO" in _read_body(result_b["file_path"])
+
+    def test_content_identical_first_100_chars_still_disambiguates(self, mock_palinode_dir):
+        """Two memories whose content is identical for the first 100+
+        characters but differs only after must still produce distinct files.
+        This is the case a prefix-hash silently fails."""
+        shared_prefix = "User thanks that helps a lot — this is an extended shared opening " + "x" * 60
+        content_a = shared_prefix + "\n\nCHARLIE — unique tail A"
+        content_b = shared_prefix + "\n\nDELTA — unique tail B"
+
+        # Verify the first 100 chars are identical
+        assert content_a[:100] == content_b[:100]
+
+        result_a = save_memory(content=content_a, type="Insight")
+        result_b = save_memory(content=content_b, type="Insight")
+
+        assert result_a["file_path"] != result_b["file_path"]
+        assert os.path.exists(result_a["file_path"])
+        assert os.path.exists(result_b["file_path"])
+        assert "CHARLIE" in _read_body(result_a["file_path"])
+        assert "DELTA" in _read_body(result_b["file_path"])
+
+    def test_explicit_slug_still_overwrites(self, mock_palinode_dir):
+        """An explicitly-passed slug must keep overwriting (documented
+        escape hatch for idempotent updates)."""
+        content_a = "First version of this note"
+        content_b = "Second version, completely different"
+
+        result_a = save_memory(content=content_a, type="Insight", slug="my-note")
+        result_b = save_memory(content=content_b, type="Insight", slug="my-note")
+
+        # Same file path — overwrite is intentional
+        assert result_a["file_path"] == result_b["file_path"]
+        # Second content wins
+        assert "Second version" in _read_body(result_b["file_path"])
+
+    def test_identical_content_resave_is_idempotent(self, mock_palinode_dir):
+        """Re-saving the exact same content (with a derived slug) must
+        hit the same file — a re-save, not a collision."""
+        content = "User thanks that helps a lot\n\nSame content saved twice"
+
+        result_a = save_memory(content=content, type="Insight")
+        result_b = save_memory(content=content, type="Insight")
+
+        # Same file path — this is a re-save, not a collision
+        assert result_a["file_path"] == result_b["file_path"]
+
+    def test_three_collisions_produce_three_files(self, mock_palinode_dir):
+        """Three saves with same opening line but different bodies produce
+        three distinct files (the full reproduction from issue #129)."""
+        contents = [
+            "User thanks that helps a lot\n\nALPHA body",
+            "User thanks that helps a lot\n\nBRAVO body",
+            "User thanks that helps a lot\n\nCHARLIE body",
+        ]
+        results = [save_memory(content=c, type="Insight") for c in contents]
+
+        paths = [r["file_path"] for r in results]
+        assert len(set(paths)) == 3, f"Expected 3 distinct paths, got: {paths}"
+
+        # All three files exist with correct content
+        for path, marker in zip(paths, ["ALPHA", "BRAVO", "CHARLIE"]):
+            assert os.path.exists(path)
+            assert marker in _read_body(path)


### PR DESCRIPTION
## Summary

Fixes #129 — when `slug` is omitted, `save_memory()` derives one from the opening words of the content. Two saves whose openings agree resolved to the same file, silently overwriting the first.

## What changed

In `palinode/core/save.py`, after deriving the slug (only when not explicitly passed):

1. Check if the target path already exists
2. If it does, compare the existing file's body to the new content
3. If different → append `sha256(full_content)[:8]` to the slug
4. Loop until the candidate filename is either unused or byte-identical (re-save)

## Design decisions (per issue guidance)

- **Hash the full content**, not a prefix — avoids the 100-char collision trap described in the issue
- **Loop until unused** — handles the astronomically unlikely case of hash[:8] collision
- **Byte-identical re-save is idempotent** — same content to the same derived slug hits the same file (not a collision, just a re-save)
- **Explicitly-passed slugs still overwrite** — the documented escape hatch for idempotent updates is preserved
- **Stays inside `core/save.py`** — does not touch `ingest/pipeline.py` (separate issue, as noted)
- **Uses `frontmatter` lib directly** to extract body for comparison (already a project dependency)
- **Fail-open on unreadable file** — matches existing pattern elsewhere in the function

## Tests

Added `tests/test_save_slug_collision.py` — 5 tests:

| Test | What it proves |
|------|---------------|
| `test_two_saves_shared_opening_produce_distinct_files` | Core fix works |
| `test_content_identical_first_100_chars_still_disambiguates` | Prefix-hash trap is avoided |
| `test_explicit_slug_still_overwrites` | Escape hatch preserved |
| `test_identical_content_resave_is_idempotent` | No spurious disambiguation |
| `test_three_collisions_produce_three_files` | Full reproduction from issue |

```
============================== 5 passed in 0.40s ===============================
```

Existing save tests (29) also pass.