### PR TITLE
perf(cli): avoid eager API imports

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **CLI startup no longer imports the FastAPI application (#143).** The
+  Obsidian sync and frontmatter migration commands now use their core-layer
+  helpers directly, avoiding the API router and provenance-UI dependency tree
+  (and its configuration-log side effects) for ordinary CLI invocations.
 - Preserve the embedding-backend 503 response for `/triggers` and
   `/check-triggers` instead of converting outages into generic 500 errors.
 - **Complete text output for `palinode lint` (#113).** The human-readable report

--- a/palinode/api/memory_write.py
+++ b/palinode/api/memory_write.py
@@ -31,6 +31,7 @@ from palinode.core.defaults import SAVE_SOURCE_HEADER
 # either path — they are the same objects.
 from palinode.core.memory_write import (  # noqa: F401
     _CATEGORY_TO_ENTITY_PREFIX,
+    _MEMORY_CATEGORY_DIRS,
     _SAFE_SLUG_RE,
     _TYPE_TO_CATEGORY,
     _WIKI_FOOTER_MARKER,
@@ -70,15 +71,6 @@ def _resolve_source(req_source: str | None, request: Request | None) -> str:
     from palinode.core.save import default_source
 
     return default_source()
-
-
-#: The memory-category directories `save_api` writes to. A file outside these
-#: (a `daily/` journal, `archive/`, `specs/` incl. `specs/prompts/`, or a
-#: top-level doc like README.md / PROGRAM.md) is structural / non-memory: the
-#: description backfill regenerates a description for it every run but
-#: `_inject_description` never persists one (no memory frontmatter to land it
-#: in), so counting it as "pending" loops the backfill forever.
-_MEMORY_CATEGORY_DIRS: frozenset[str] = frozenset(_TYPE_TO_CATEGORY.values())
 
 
 def _is_description_eligible(relpath: str) -> bool:

--- a/palinode/cli/obsidian_sync.py
+++ b/palinode/cli/obsidian_sync.py
@@ -37,9 +37,9 @@ from typing import Optional
 
 import click
 
-from palinode.api.server import _apply_wiki_footer
 from palinode.core import git_tools
 from palinode.core.config import config
+from palinode.core.memory_write import _apply_wiki_footer
 from palinode.core.parser import parse_markdown
 
 # Directories skipped by all palinode tooling — mirrors lint.py's skip set

--- a/palinode/core/memory_write.py
+++ b/palinode/core/memory_write.py
@@ -158,3 +158,7 @@ _TYPE_TO_CATEGORY: dict[str, str] = {
     "ResearchRef": "research",
     "ActionItem": "inbox",
 }
+
+#: The memory-category directories the save path writes to. Keep this next to
+#: ``_TYPE_TO_CATEGORY`` so core consumers do not need to import the API layer.
+_MEMORY_CATEGORY_DIRS: frozenset[str] = frozenset(_TYPE_TO_CATEGORY.values())

--- a/palinode/migration/frontmatter_backfill.py
+++ b/palinode/migration/frontmatter_backfill.py
@@ -91,9 +91,9 @@ from typing import Any, Literal
 import frontmatter as _frontmatter
 import yaml
 
-from palinode.api.memory_write import _MEMORY_CATEGORY_DIRS, _TYPE_TO_CATEGORY
 from palinode.core import git_tools
 from palinode.core.config import config
+from palinode.core.memory_write import _MEMORY_CATEGORY_DIRS, _TYPE_TO_CATEGORY
 
 logger = logging.getLogger("palinode.migration.frontmatter_backfill")
 

--- a/tests/test_cli_import_boundary.py
+++ b/tests/test_cli_import_boundary.py
@@ -1,0 +1,26 @@
+"""Import-boundary regressions for the CLI package."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_cli_import_does_not_pull_in_fastapi() -> None:
+    """A plain CLI import must not initialize the API dependency tree."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; import palinode.cli; "
+                "print('fastapi' in sys.modules); "
+                "print('palinode.api.server' in sys.modules)"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == ["False", "False"]


### PR DESCRIPTION
## Summary

- import the Obsidian wiki-footer helper directly from its core definition instead of through `palinode.api.server`
- move `_MEMORY_CATEGORY_DIRS` beside `_TYPE_TO_CATEGORY` in `palinode.core.memory_write`, while preserving the historical API re-export
- add a subprocess regression proving a plain `palinode.cli` import loads neither FastAPI nor `palinode.api.server`

Fixes #143.

## Import-time measurement

Measured with Python 3.11 using five fresh post-warmup subprocesses per revision:

```text
PYTHONPATH=. python -X importtime -c "import palinode.cli"
```

- before: median cumulative `palinode.cli` import time **331 ms** (323-367 ms)
- after: median cumulative `palinode.cli` import time **188 ms** (187-210 ms)
- change: **143 ms / 43% lower median cumulative import time**

Before this change, the trace included `palinode.api.server` (about 78-81 ms cumulative in the measured runs). After the change, that module is absent; a direct module check also reports both `fastapi` and `palinode.api.server` as unloaded.

## Validation

- focused import/Obsidian/frontmatter/wiki-footer tests: **99 passed**
- complete suite: **3130 passed, 10 skipped, 5 xfailed**
- `ruff check palinode/ tests/ scripts/`
- `bandit -r palinode/ -ll`
- `git diff --check`

AI assistance disclosure: I used OpenAI Codex to help inspect the import graph, implement the scoped change, run measurements, and validate the patch. I reviewed the final diff and evidence before submitting.