### PR TITLE
fix(api): keep reindex off event loop

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **Reindexing no longer blocks the API event loop.** The `/reindex` handler
+  now runs in FastAPI's threadpool and uses an atomic non-blocking process-wide
+  lock, preserving immediate 409 responses for concurrent requests while
+  `/health` and other endpoints stay responsive.
 - **CLI startup no longer imports the FastAPI application (#143).** The
   Obsidian sync and frontmatter migration commands now use their core-layer
   helpers directly, avoiding the API router and provenance-UI dependency tree

--- a/palinode/api/_util.py
+++ b/palinode/api/_util.py
@@ -10,10 +10,10 @@ reindex / auto-summary observability state dicts.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import re
+import threading
 from datetime import UTC, datetime
 from typing import Any
 
@@ -74,10 +74,10 @@ def _project_from_cwd(cwd: str | None) -> str | None:
 
 
 # ── Reindex concurrency guard ─────────────────────────────────────────
-# asyncio.Lock is safe because FastAPI runs on a single event loop.  The
-# reindex work itself is synchronous (file I/O + Ollama HTTP) but the lock
-# acquisition is async so concurrent HTTP callers fail fast rather than queue.
-_reindex_lock = asyncio.Lock()
+# The synchronous reindex handler runs in FastAPI's threadpool.  A process-wide
+# threading lock provides mutual exclusion across worker threads; callers use a
+# non-blocking acquire so a concurrent request fails fast instead of queueing.
+_reindex_lock = threading.Lock()
 _reindex_state: dict[str, Any] = {
     "running": False,
     "started_at": None,

--- a/palinode/api/routers/maintenance.py
+++ b/palinode/api/routers/maintenance.py
@@ -84,7 +84,7 @@ def rebuild_fts_api() -> dict[str, Any]:
 
 
 @router.post("/reindex")
-async def reindex_api(since: str | None = None) -> dict[str, Any]:
+def reindex_api(since: str | None = None) -> dict[str, Any]:
     """Reindex memory files.  Idempotent — unchanged files are skipped.
 
     Query params:
@@ -96,30 +96,30 @@ async def reindex_api(since: str | None = None) -> dict[str, Any]:
     Returns 409 if a reindex is already in progress — check /status for
     progress.
     """
-    if _reindex_lock.locked():
+    if not _reindex_lock.acquire(blocking=False):
         raise HTTPException(
             status_code=409,
             detail="reindex already running — check /status for progress",
         )
 
-    from palinode.indexer.watcher import PalinodeHandler
-    handler = PalinodeHandler()
+    try:
+        from palinode.indexer.watcher import PalinodeHandler
+        handler = PalinodeHandler()
 
-    since_ts: float | None = None
-    if since:
-        try:
-            dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
-            since_ts = dt.timestamp()
-        except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid ISO timestamp: {since}")
+        since_ts: float | None = None
+        if since:
+            try:
+                dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+                since_ts = dt.timestamp()
+            except ValueError:
+                raise HTTPException(status_code=400, detail=f"Invalid ISO timestamp: {since}")
 
-    files = [
-        fp
-        for fp in glob.glob(os.path.join(config.palinode_dir, "**/*.md"), recursive=True)
-        if handler.is_valid_file(fp)
-    ]
+        files = [
+            fp
+            for fp in glob.glob(os.path.join(config.palinode_dir, "**/*.md"), recursive=True)
+            if handler.is_valid_file(fp)
+        ]
 
-    async with _reindex_lock:
         _reindex_state["running"] = True
         _reindex_state["started_at"] = _utc_now().isoformat().replace("+00:00", "Z")
         _reindex_state["files_processed"] = 0
@@ -157,15 +157,17 @@ async def reindex_api(since: str | None = None) -> dict[str, Any]:
         finally:
             _reindex_state["running"] = False
 
-    return {
-        "status": "success",
-        "files_reindexed": count,
-        "skipped_not_modified": skipped_mtime,
-        "errors": errors,
-        "gc_paths_removed": gc_paths_removed,
-        "gc_chunks_removed": gc_chunks_removed,
-        "fts_chunks": fts_count,
-    }
+        return {
+            "status": "success",
+            "files_reindexed": count,
+            "skipped_not_modified": skipped_mtime,
+            "errors": errors,
+            "gc_paths_removed": gc_paths_removed,
+            "gc_chunks_removed": gc_chunks_removed,
+            "fts_chunks": fts_count,
+        }
+    finally:
+        _reindex_lock.release()
 
 
 @router.get("/entities/{entity_ref:path}")

--- a/tests/test_reindex_concurrency.py
+++ b/tests/test_reindex_concurrency.py
@@ -13,6 +13,7 @@ suite stays Ollama-free and fast.  Config is redirected via memory_dir
 from __future__ import annotations
 
 import threading
+import time
 from unittest import mock
 
 import pytest
@@ -79,9 +80,11 @@ def test_single_reindex_succeeds(client):
 
 def test_409_detail_message(client):
     """While the lock is held a second POST must get 409 with a clear message."""
-    # Mock the lock as locked so the guard fires without needing a live async lock.
-    with mock.patch.object(srv._reindex_lock, "locked", return_value=True):
+    assert srv._reindex_lock.acquire(blocking=False)
+    try:
         resp = client.post("/reindex")
+    finally:
+        srv._reindex_lock.release()
 
     assert resp.status_code == 409
     body = resp.json()
@@ -91,39 +94,106 @@ def test_409_detail_message(client):
     assert "/status" in detail
 
 
+def test_invalid_since_releases_lock(client):
+    """An early validation error must not leave future reindexes locked out."""
+    response = client.post("/reindex", params={"since": "not-a-timestamp"})
+
+    assert response.status_code == 400
+    assert srv._reindex_lock.acquire(blocking=False)
+    srv._reindex_lock.release()
+
+
 def test_concurrent_calls_one_wins_one_loses(client):
-    """Two truly concurrent calls: one 200, one 409.
+    """Two concurrent POSTs run the underlying reindex exactly once."""
+    start_requests = threading.Barrier(3)
+    work_started = threading.Event()
+    release_work = threading.Event()
+    rejected = threading.Event()
+    responses = []
+    work_calls = []
+    responses_lock = threading.Lock()
 
-    We hold the asyncio lock from a background thread so the second HTTP
-    request fires while the first is in progress.
-    """
-    lock_held = threading.Event()
-    release_lock = threading.Event()
+    def _slow_process(_self, filepath):
+        work_calls.append(filepath)
+        work_started.set()
+        assert release_work.wait(timeout=5)
 
-    def _hold_lock():
-        """Acquire the reindex lock from a new event loop, signal, then wait."""
-        import asyncio
+    def _post_reindex():
+        start_requests.wait(timeout=5)
+        response = client.post("/reindex")
+        with responses_lock:
+            responses.append(response)
+        if response.status_code == 409:
+            rejected.set()
 
-        async def _inner():
-            async with srv._reindex_lock:
-                srv._reindex_state["running"] = True
-                lock_held.set()
-                await asyncio.get_event_loop().run_in_executor(None, release_lock.wait)
-            srv._reindex_state["running"] = False
+    threads = [threading.Thread(target=_post_reindex, daemon=True) for _ in range(2)]
+    with (
+        mock.patch("glob.glob", return_value=["/tmp/reindex.md"]),
+        mock.patch(
+            "palinode.indexer.watcher.PalinodeHandler.is_valid_file",
+            return_value=True,
+        ),
+        mock.patch(
+            "palinode.indexer.watcher.PalinodeHandler._process_file",
+            new=_slow_process,
+        ),
+        mock.patch("palinode.core.store.gc_orphaned_chunks", return_value=(0, 0)),
+        mock.patch("palinode.core.store.rebuild_fts", return_value=0),
+    ):
+        for thread in threads:
+            thread.start()
+        start_requests.wait(timeout=5)
+        assert work_started.wait(timeout=5)
+        assert rejected.wait(timeout=5)
+        release_work.set()
+        for thread in threads:
+            thread.join(timeout=5)
 
-        asyncio.run(_inner())
+    assert not any(thread.is_alive() for thread in threads)
+    assert sorted(response.status_code for response in responses) == [200, 409]
+    assert work_calls == ["/tmp/reindex.md"]
 
-    lock_thread = threading.Thread(target=_hold_lock, daemon=True)
-    lock_thread.start()
-    lock_held.wait(timeout=5)
 
-    try:
-        # Second POST fires while the lock is held — must be 409.
-        resp = client.post("/reindex")
-        assert resp.status_code == 409
-    finally:
-        release_lock.set()
-        lock_thread.join(timeout=5)
+def test_health_responds_while_reindex_runs(client):
+    """Blocking reindex work must not occupy the API event loop."""
+    work_started = threading.Event()
+    release_work = threading.Event()
+    reindex_responses = []
+
+    def _slow_process(_self, _filepath):
+        work_started.set()
+        assert release_work.wait(timeout=5)
+
+    def _post_reindex():
+        reindex_responses.append(client.post("/reindex"))
+
+    reindex_thread = threading.Thread(target=_post_reindex, daemon=True)
+    with (
+        mock.patch("glob.glob", return_value=["/tmp/reindex.md"]),
+        mock.patch(
+            "palinode.indexer.watcher.PalinodeHandler.is_valid_file",
+            return_value=True,
+        ),
+        mock.patch(
+            "palinode.indexer.watcher.PalinodeHandler._process_file",
+            new=_slow_process,
+        ),
+        mock.patch("palinode.core.store.gc_orphaned_chunks", return_value=(0, 0)),
+        mock.patch("palinode.core.store.rebuild_fts", return_value=0),
+        mock.patch("httpx.get"),
+    ):
+        reindex_thread.start()
+        assert work_started.wait(timeout=5)
+        started_at = time.monotonic()
+        health_response = client.get("/health")
+        elapsed = time.monotonic() - started_at
+        release_work.set()
+        reindex_thread.join(timeout=5)
+
+    assert not reindex_thread.is_alive()
+    assert health_response.status_code == 200
+    assert elapsed < 1.0
+    assert [response.status_code for response in reindex_responses] == [200]
 
 
 def test_reindex_state_resets_after_completion(client):


### PR DESCRIPTION
## Summary

- run the blocking `POST /reindex` handler in FastAPI's threadpool by making it synchronous
- replace the event-loop lock with a process-wide threading lock and an atomic non-blocking acquire, always released in `finally`
- add regression coverage proving the API stays responsive and that two concurrent reindexes still produce exactly one 200 and one 409
- document the fix under the Unreleased changelog

## Why

The old async handler performed file I/O, embedding HTTP calls, and SQLite writes directly on the event loop. Converting it to a normal FastAPI handler keeps other API and MCP requests responsive, while the atomic lock guard preserves the existing fail-fast concurrency contract without a check-then-acquire race.

## Validation

- `.venv/bin/pytest -q tests/test_reindex_concurrency.py` — 9 passed
- `.venv/bin/pytest -q` — 3132 passed, 10 skipped, 5 xfailed
- `.venv/bin/ruff check palinode/ tests/ scripts/`
- `.venv/bin/bandit -r palinode/ -ll -q`
- `git diff --check`

Closes #142