### PR TITLE
test(executor): decode executor outputs as UTF-8, not the locale default

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -27,16 +27,17 @@ category: project
 - [2024-01-01] The project started today <!-- fact:f1 -->
 - [2024-01-02] An update occurred <!-- fact:f2 -->
 - [2024-01-03] Another update <!-- fact:f3 -->
+- [2024-01-04] Rollout to the café team — 日本語 notes <!-- fact:f4 -->
 """
     path = tmp_path / "project-alpha.md"
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
     return str(path)
 
 def test_keep_operation(temp_memory_file):
     ops = [{"op": "KEEP", "id": "f1"}]
     stats = apply_operations(temp_memory_file, ops)
     assert stats["kept"] == 1
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         content = f.read()
     assert "The project started today <!-- fact:f1 -->" in content
 
@@ -44,7 +45,7 @@ def test_update_operation(temp_memory_file):
     ops = [{"op": "UPDATE", "id": "f2", "new_text": "- [2024-01-02] A significant update occurred"}]
     stats = apply_operations(temp_memory_file, ops)
     assert stats["updated"] == 1
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         content = f.read()
     assert "A significant update occurred <!-- fact:f2 -->" in content
     assert "An update occurred" not in content
@@ -53,7 +54,7 @@ def test_merge_operation(temp_memory_file):
     ops = [{"op": "MERGE", "ids": ["f2", "f3"], "new_text": "- [2024-01-02] Important combined updates"}]
     stats = apply_operations(temp_memory_file, ops)
     assert stats["merged"] == 1
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         content = f.read()
     assert "Important combined updates <!-- fact:merged-f2 -->" in content
     assert "<!-- fact:f3 -->" not in content
@@ -62,7 +63,7 @@ def test_supersede_operation(temp_memory_file):
     ops = [{"op": "SUPERSEDE", "id": "f1", "new_text": "- [2024-01-04] The project was restarted", "reason": "Change of plans"}]
     stats = apply_operations(temp_memory_file, ops)
     assert stats["superseded"] == 1
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         content = f.read()
     assert "~~[2024-01-01] The project started today~~" in content
     assert "The project was restarted <!-- fact:supersedes-f1 -->" in content
@@ -70,7 +71,7 @@ def test_supersede_operation(temp_memory_file):
     # Check history file
     history_file = temp_memory_file.replace(".md", "-history.md")
     assert os.path.exists(history_file)
-    with open(history_file) as f:
+    with open(history_file, encoding="utf-8") as f:
         hist = f.read()
     assert "Superseded" in hist
     os.remove(history_file)
@@ -79,13 +80,13 @@ def test_archive_operation(temp_memory_file):
     ops = [{"op": "ARCHIVE", "id": "f2", "reason": "No longer relevant"}]
     stats = apply_operations(temp_memory_file, ops)
     assert stats["archived"] == 1
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         content = f.read()
     assert "An update occurred" not in content
     
     history_file = temp_memory_file.replace(".md", "-history.md")
     assert os.path.exists(history_file)
-    with open(history_file) as f:
+    with open(history_file, encoding="utf-8") as f:
         hist = f.read()
     assert "Archived" in hist
     # the history file must carry `status: archived` so the relocated
@@ -119,17 +120,17 @@ def test_missing_fact_id_is_noop(temp_memory_file):
     assert not os.path.exists(temp_memory_file.replace(".md", "-history.md"))
 
 def test_empty_operations_leave_file_unchanged(temp_memory_file):
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         before = f.read()
     stats = apply_operations(temp_memory_file, [])
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         after = f.read()
     assert before == after
     assert stats == {"kept": 0, "updated": 0, "merged": 0, "superseded": 0, "archived": 0, "retracted": 0, "merge_rejected": 0, "protected_rejected": 0, "contradicts_proposed": 0, "unmatched": 0}
 
 
 def test_atomic_main_write_failure_preserves_original_file(temp_memory_file, monkeypatch):
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         before = f.read()
 
     def fail_replace(src, dst):
@@ -143,7 +144,7 @@ def test_atomic_main_write_failure_preserves_original_file(temp_memory_file, mon
             [{"op": "UPDATE", "id": "f2", "new_text": "- [2024-01-02] A significant update occurred"}],
         )
 
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         after = f.read()
 
     assert after == before
@@ -157,7 +158,7 @@ def test_atomic_main_write_failure_preserves_original_file(temp_memory_file, mon
 
 
 def test_atomic_history_write_failure_preserves_original_file(temp_memory_file, monkeypatch):
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         before = f.read()
 
     history_file = temp_memory_file.replace(".md", "-history.md")
@@ -183,7 +184,7 @@ def test_atomic_history_write_failure_preserves_original_file(temp_memory_file, 
             ],
         )
 
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         after = f.read()
 
     assert after == before
@@ -201,7 +202,7 @@ def test_atomic_history_write_failure_preserves_original_file(temp_memory_file, 
 
 
 def test_atomic_history_new_file_creation_failure_cleans_temp_file(temp_memory_file, monkeypatch):
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         before = f.read()
 
     history_file = temp_memory_file.replace(".md", "-history.md")
@@ -220,7 +221,7 @@ def test_atomic_history_new_file_creation_failure_cleans_temp_file(temp_memory_f
             [{"op": "ARCHIVE", "id": "f2", "reason": "No longer relevant"}],
         )
 
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         after = f.read()
 
     assert after == before
@@ -254,7 +255,7 @@ def test_atomic_write_directory_fsync_failure_propagates_and_cleans_temp(temp_me
             [{"op": "UPDATE", "id": "f2", "new_text": "- [2024-01-02] A significant update occurred"}],
         )
 
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         content = f.read()
 
     assert "A significant update occurred <!-- fact:f2 -->" in content
@@ -272,7 +273,7 @@ def test_replace_policy_parse_exception_warns_and_falls_open(
     monkeypatch,
     caplog,
 ):
-    with open(temp_memory_file, "w") as f:
+    with open(temp_memory_file, "w", encoding="utf-8") as f:
         f.write(
             "---\nid: living-doc\nupdate_policy: replace\n---\n\n"
             "- [2024-01-01] Current living fact <!-- fact:f1 -->\n"
@@ -304,7 +305,7 @@ def test_replace_policy_corrupt_metadata_warning_warns_and_falls_open(
     monkeypatch,
     caplog,
 ):
-    with open(temp_memory_file, "w") as f:
+    with open(temp_memory_file, "w", encoding="utf-8") as f:
         f.write(
             "---\nid: living-doc\nupdate_policy: replace\n---\n\n"
             "- [2024-01-01] Current living fact <!-- fact:f1 -->\n"
@@ -336,7 +337,7 @@ def test_retract_operation(temp_memory_file):
     ops = [{"op": "RETRACT", "id": "f2", "reason": "This was never true"}]
     stats = apply_operations(temp_memory_file, ops)
     assert stats["retracted"] == 1
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         content = f.read()
     # Fact should be struck through with RETRACTED label
     assert "~~[2024-01-02] An update occurred~~" in content
@@ -348,7 +349,7 @@ def test_retract_operation(temp_memory_file):
     # Check history file
     history_file = temp_memory_file.replace(".md", "-history.md")
     assert os.path.exists(history_file)
-    with open(history_file) as f:
+    with open(history_file, encoding="utf-8") as f:
         hist = f.read()
     assert "Retracted" in hist
     assert "This was never true" in hist
@@ -360,7 +361,7 @@ def test_retract_without_reason(temp_memory_file):
     ops = [{"op": "RETRACT", "id": "f1"}]
     stats = apply_operations(temp_memory_file, ops)
     assert stats["retracted"] == 1
-    with open(temp_memory_file) as f:
+    with open(temp_memory_file, encoding="utf-8") as f:
         content = f.read()
     assert "~~[2024-01-01] The project started today~~" in content
     assert "[RETRACTED" in content
@@ -408,7 +409,7 @@ category: project
 - [2026-04-27] Yesterday's note <!-- fact:s3 -->
 """
     path = tmp_path / "project-beta.md"
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
     return str(path)
 
 
@@ -418,7 +419,7 @@ def test_nightly_merge_accepts_same_day(temp_same_day_file):
     stats = apply_operations(temp_same_day_file, ops, nightly_policy=True)
     assert stats["merged"] == 1
     assert stats["merge_rejected"] == 0
-    with open(temp_same_day_file) as f:
+    with open(temp_same_day_file, encoding="utf-8") as f:
         content = f.read()
     assert "Combined daily note" in content
     # s2 should be gone after the merge
@@ -432,7 +433,7 @@ def test_nightly_merge_rejects_cross_date(temp_same_day_file):
     assert stats["merged"] == 0
     assert stats["merge_rejected"] == 1
     # File content should be unchanged
-    with open(temp_same_day_file) as f:
+    with open(temp_same_day_file, encoding="utf-8") as f:
         content = f.read()
     assert "Morning session note" in content
     assert "Yesterday's note" in content
@@ -441,7 +442,7 @@ def test_nightly_merge_rejects_cross_date(temp_same_day_file):
 def test_nightly_merge_rejects_undated_fact(temp_same_day_file):
     """nightly_policy=True: MERGE involving a fact without a date is rejected."""
     # Patch in an undated fact
-    with open(temp_same_day_file, "a") as f:
+    with open(temp_same_day_file, "a", encoding="utf-8") as f:
         f.write("- Undated note <!-- fact:s4 -->\n")
     ops = [{"op": "MERGE", "ids": ["s1", "s4"], "new_text": "[2026-04-28] Merged"}]
     stats = apply_operations(temp_same_day_file, ops, nightly_policy=True)

--- a/tests/test_executor_replace_guard.py
+++ b/tests/test_executor_replace_guard.py
@@ -33,7 +33,7 @@ def _memory_dir(tmp_path, monkeypatch):
 def _write(content: str, *, _dir=None) -> str:
     directory = _dir if _dir is not None else config.memory_dir
     path = os.path.join(directory, f"{uuid.uuid4().hex}.md")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(content)
     return path
 
@@ -95,7 +95,7 @@ def test_supersede_refused_on_replace_doc(replace_doc):
     assert stats["superseded"] == 0
     assert stats["protected_rejected"] == 1
 
-    with open(replace_doc) as f:
+    with open(replace_doc, encoding="utf-8") as f:
         content = f.read()
     # Original fact untouched: no strikethrough, no supersedes- sibling.
     assert "~~" not in content
@@ -112,7 +112,7 @@ def test_archive_refused_on_replace_doc(replace_doc):
     assert stats["archived"] == 0
     assert stats["protected_rejected"] == 1
 
-    with open(replace_doc) as f:
+    with open(replace_doc, encoding="utf-8") as f:
         content = f.read()
     # Fact still present — not removed into history.
     assert "uptime-kuma is DOWN (HTTP 502) <!-- fact:f1 -->" in content
@@ -132,7 +132,7 @@ def test_supersede_still_works_on_episodic_doc(episodic_doc):
     assert stats["superseded"] == 1
     assert stats["protected_rejected"] == 0
 
-    with open(episodic_doc) as f:
+    with open(episodic_doc, encoding="utf-8") as f:
         content = f.read()
     assert "~~[2024-01-01] The project started today~~" in content
     assert "The project was restarted <!-- fact:supersedes-f1 -->" in content
@@ -146,7 +146,7 @@ def test_archive_still_works_on_episodic_doc(episodic_doc):
     assert stats["archived"] == 1
     assert stats["protected_rejected"] == 0
 
-    with open(episodic_doc) as f:
+    with open(episodic_doc, encoding="utf-8") as f:
         content = f.read()
     assert "The project started today" not in content
     assert os.path.exists(episodic_doc.replace(".md", "-history.md"))
@@ -165,7 +165,7 @@ def test_update_still_allowed_on_replace_doc(replace_doc):
     assert stats["updated"] == 1
     assert stats["protected_rejected"] == 0
 
-    with open(replace_doc) as f:
+    with open(replace_doc, encoding="utf-8") as f:
         content = f.read()
     assert "uptime-kuma is UP (HTTP 200) <!-- fact:f1 -->" in content
     assert "is DOWN (HTTP 502)" not in content
@@ -188,7 +188,7 @@ def test_retract_refused_on_replace_doc(replace_doc):
     assert stats["retracted"] == 0
     assert stats["protected_rejected"] == 1
 
-    with open(replace_doc) as f:
+    with open(replace_doc, encoding="utf-8") as f:
         content = f.read()
     # Original fact untouched: no strikethrough tombstone in the living doc.
     assert "~~" not in content
@@ -205,6 +205,6 @@ def test_retract_allowed_on_episodic_doc(episodic_doc):
 
     assert stats["retracted"] == 1
     assert stats["protected_rejected"] == 0
-    with open(episodic_doc) as f:
+    with open(episodic_doc, encoding="utf-8") as f:
         content = f.read()
     assert "[RETRACTED" in content

--- a/tests/test_utf8_encoding_guard.py
+++ b/tests/test_utf8_encoding_guard.py
@@ -47,6 +47,17 @@ _ALLOWLIST: tuple[tuple[str, str], ...] = (
     ("palinode/migration/mem0_generate.py", "open("),
 )
 
+# Test files whose reads and writes have been swept, listed one area at a time
+# as the native-Windows cleanup works through them. A file joins this tuple in
+# the same PR that sweeps it, so a later edit cannot quietly reintroduce a
+# locale-default call into an area already fixed. The rest of ``tests/`` is
+# deliberately absent: the scope is helpers exchanging files Palinode itself
+# wrote as UTF-8, not every locale-default call in the test tree.
+_SWEPT_TEST_FILES: tuple[str, ...] = (
+    "tests/test_executor.py",
+    "tests/test_executor_replace_guard.py",
+)
+
 _TEXT_MODE_TEMPFILE = {"NamedTemporaryFile", "TemporaryFile", "SpooledTemporaryFile"}
 _SUBPROCESS_TEXT = {"run", "Popen", "check_output", "call", "check_call"}
 
@@ -232,4 +243,22 @@ def test_non_ascii_memory_roundtrips_under_ascii_locale(tmp_path: Path) -> None:
     assert proc.returncode == 0 and out.endswith("OK"), (
         f"non-ASCII memory failed to round-trip under an ASCII locale\n"
         f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_swept_test_files_name_their_encoding() -> None:
+    """Test areas already swept for native Windows stay swept."""
+    offenders: list[str] = []
+    missing: list[str] = []
+    for rel in _SWEPT_TEST_FILES:
+        path = REPO_ROOT / rel
+        if not path.exists():
+            missing.append(rel)
+            continue
+        for lineno, segment in _scan(path):
+            offenders.append(f"{rel}:{lineno}: {segment}")
+    assert not missing, f"swept file no longer exists; update _SWEPT_TEST_FILES: {missing}"
+    assert not offenders, (
+        "text-mode I/O without encoding= in a test area already swept for "
+        'native Windows - add encoding="utf-8":\n  ' + "\n  ".join(offenders)
     )


### PR DESCRIPTION
First of the area-based PRs for #93. This one is executor outputs: `test_executor.py` and `test_executor_replace_guard.py`.

## What changed

34 text-mode reads and writes in those two files now name `encoding="utf-8"`. Every one of them touches a file the executor wrote through `write_memory_file`, which is UTF-8 on the source side after v0.14.0, so the test side was the only half still decoding with the locale default.

I also added one non-ASCII fact to the `temp_memory_file` fixture. Without it the sweep is unfalsifiable on any UTF-8 host, which is the trap you named on the case-2 test in the other direction.

## Reproduction

`LC_ALL=C` gives US-ASCII on this machine, so the Windows failure is reachable on macOS. Same technique `test_utf8_encoding_guard.py` already uses for the source side.

Unfixed, with the new fixture content:

```
LC_ALL=C LANG=C PYTHONUTF8=0 pytest tests/test_executor.py
7 passed, 19 errors
```

The errors are `UnicodeEncodeError` and `UnicodeDecodeError`. Fixed, same command, both files:

```
33 passed
```

Under the default UTF-8 locale both versions pass, which is why the fixture change has to be part of this rather than a follow-up.

## Regression guard

`_SWEPT_TEST_FILES` in `test_utf8_encoding_guard.py`, plus a test over it that reuses the existing `_scan`. A file joins the tuple in the PR that sweeps it. I checked the guard fails when a swept site loses its `encoding=`, not just that it passes now.

The rest of `tests/` is deliberately not in there. The scope is still the relevance filter we agreed, not every locale-default call in the tree.

## Gates

Full suite: 3232 passed, 10 skipped, 5 xfailed. `ruff check tests/` clean.

Two comments I wrote tripped `test_no_issue_refs_user_surface.py`, in comments and docstrings both. I reworded rather than adding the URL, since the module docstring already carries it.

Still on macOS, so this does not give you the native-Windows run the issue also asks for.

## Remaining areas

Inventory re-derived on `a27d9b3` using the repo's own detector rather than my earlier one, which is why the number moved again: 514 sites across 104 test files, since `_is_unencoded_text_io` also catches `Path.open`, `os.fdopen`, text-mode `tempfile` and `subprocess(text=True)` that neither of our AST walks counted.

Next up, in the order we agreed: `/save` output paths, daily and status files, archive history.