### PR TITLE
bench: add standalone search abstention evaluation

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -35,6 +35,26 @@ If a `bge-m3` embedder is reachable (e.g. the Docker Compose stack), the harness
 embedded/hybrid path. If not, it **degrades gracefully to keyword-only** and reports those numbers
 honestly — which is itself axis 4.
 
+## Standalone abstention evaluation
+
+The abstention evaluation is intentionally separate from the four-axis runner while its protocol
+is still evolving. It requires a real configured embedding endpoint and runs the real SQLite-vec,
+FTS5, and hybrid-ranking paths against a throwaway store. It sweeps the per-arm relevance floor
+across three corpus seeds, measuring query-level false positives for 26 no-answer queries alongside
+20 answer-present controls per seed. It does not change production search defaults.
+
+```bash
+# complete observations + aggregate summaries
+python -m bench.abstention --out abstention.json
+
+# reviewable aggregate table
+python -m bench.abstention --format markdown --out abstention.md
+```
+
+The pinned query shapes are natural-language questions, short keywords, absent identifiers/codes,
+exact-topic controls, and natural-language paraphrase controls. Each false-positive observation
+records both the fused score exposed to callers and the underlying raw cosine when available.
+
 ## Layout
 
 | File | Purpose |
@@ -43,9 +63,11 @@ honestly — which is itself axis 4.
 | `harness.py` | Ingest, state-fingerprint, and recall-latency measurement primitives. |
 | `run.py` | End-to-end orchestrator (the four axes) + CLI. |
 | `report.py` | Renders a results JSON object as a Markdown report. |
+| `abstention.py` | Standalone no-answer/control threshold sweep + JSON/Markdown output. |
 
 ## Tests
 
 ```bash
 python -m pytest tests/test_bench_harness.py -q
+python -m pytest tests/test_bench_abstention.py -q
 ```

--- a/bench/abstention.py
+++ b/bench/abstention.py
@@ -10,6 +10,14 @@ The evaluation asks two questions together:
 It deliberately uses the real index, SQLite-vec, FTS5, ranking pipeline, and
 configured embedding endpoint. Production search defaults are never changed.
 
+Protocol provenance: this pinned query set supersedes the exploratory run at
+https://github.com/phasespace-labs/palinode/issues/73#issuecomment-5421219548.
+Packaging the experiment replaced all 26 no-answer strings and reworded all
+10 paraphrase controls; corpus seeds, size, exact controls, top-k, and thresholds
+stayed the same. The 2026-08-26 14:24 UTC BGE-M3 run reported in
+https://github.com/phasespace-labs/palinode/pull/151 uses this pinned set: at 0.45
+it returned hits for 25/78 no-answer queries, not the exploratory set's 3/78.
+
 Run JSON and Markdown forms independently of the stable benchmark runner::
 
     python -m bench.abstention --out abstention.json
@@ -434,7 +442,7 @@ def _control_ratio(row: dict[str, Any]) -> str:
 
 def _format_score_stats(stats: dict[str, float] | None) -> str:
     if stats is None:
-        return "—"
+        return "n/a"
     return f"{stats['min']:.3f} / {stats['median']:.3f} / {stats['max']:.3f}"
 
 

--- a/bench/abstention.py
+++ b/bench/abstention.py
@@ -1,0 +1,545 @@
+"""Standalone measurement of search abstention on a seeded corpus.
+
+The evaluation asks two questions together:
+
+* How often does search return at least one result when the seeded store has
+  no true answer?
+* How often do answer-present controls retain their true result as the
+  per-arm relevance threshold increases?
+
+It deliberately uses the real index, SQLite-vec, FTS5, ranking pipeline, and
+configured embedding endpoint. Production search defaults are never changed.
+
+Run JSON and Markdown forms independently of the stable benchmark runner::
+
+    python -m bench.abstention --out abstention.json
+    python -m bench.abstention --format markdown --out abstention.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import sys
+import tempfile
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Sequence
+
+from bench import corpus, harness
+
+
+ABSENT_NATURAL_QUERIES: tuple[str, ...] = (
+    "Which region hosts the disaster recovery control plane?",
+    "Who approved the quantum-resistant signing rollout?",
+    "When does the mobile release enter beta?",
+    "What is the payroll retention policy?",
+    "How many GPU nodes are reserved for training?",
+    "Which vendor supplies the observability pipeline?",
+    "Why was the message broker replaced?",
+    "Where are customer encryption keys rotated?",
+    "What caused the invoice reconciliation outage?",
+    "Who owns the Kubernetes cluster upgrade?",
+)
+
+ABSENT_KEYWORD_QUERIES: tuple[str, ...] = (
+    "disaster recovery",
+    "quantum signing",
+    "mobile beta",
+    "payroll retention",
+    "gpu reservation",
+    "observability vendor",
+    "message broker",
+    "encryption keys",
+    "invoice outage",
+    "kubernetes upgrade",
+)
+
+ABSENT_IDENTIFIER_QUERIES: tuple[str, ...] = (
+    "INC-9472",
+    "RFC-8841",
+    "JIRA-PLAT-611",
+    "customer_eu_2048",
+    "sha256:deadbeefcafefeed",
+    "urn:palinode:absent:42",
+)
+
+PARAPHRASE_CONTROLS: tuple[tuple[str, str], ...] = (
+    ("moving persistent data to a new schema", "database migration"),
+    ("plan for reusing cached responses", "caching strategy"),
+    ("renewing authentication credentials safely", "auth token rotation"),
+    ("ordering retrieval results by relevance", "search ranking"),
+    ("checking configuration values before startup", "config validation"),
+    ("spacing repeated attempts after failures", "retry backoff"),
+    ("recreating the search index from source files", "index rebuild"),
+    ("controlling how many requests are accepted", "rate limiting"),
+    ("tracking changes to stored data formats", "schema versioning"),
+    ("finishing queued work before shutdown", "queue draining"),
+)
+
+ABSENT_KINDS = frozenset(
+    {"absent_natural", "absent_keyword", "absent_identifier"}
+)
+CONTROL_KINDS = frozenset({"control_exact", "control_paraphrase"})
+QUERY_KINDS = ABSENT_KINDS | CONTROL_KINDS
+MODES: tuple[str, ...] = ("vector", "hybrid")
+
+
+@dataclass(frozen=True)
+class QueryCase:
+    """One pinned query and, for controls, the topic that must be retrieved."""
+
+    case_id: str
+    kind: str
+    query: str
+    expected_topic: str | None = None
+
+
+DEFAULT_QUERY_CASES: tuple[QueryCase, ...] = (
+    *(
+        QueryCase(f"absent-natural-{index:02d}", "absent_natural", query)
+        for index, query in enumerate(ABSENT_NATURAL_QUERIES, start=1)
+    ),
+    *(
+        QueryCase(f"absent-keyword-{index:02d}", "absent_keyword", query)
+        for index, query in enumerate(ABSENT_KEYWORD_QUERIES, start=1)
+    ),
+    *(
+        QueryCase(f"absent-identifier-{index:02d}", "absent_identifier", query)
+        for index, query in enumerate(ABSENT_IDENTIFIER_QUERIES, start=1)
+    ),
+    *(
+        QueryCase(f"control-exact-{index:02d}", "control_exact", topic, topic)
+        for index, topic in enumerate(corpus.TOPICS, start=1)
+    ),
+    *(
+        QueryCase(
+            f"control-paraphrase-{index:02d}",
+            "control_paraphrase",
+            query,
+            topic,
+        )
+        for index, (query, topic) in enumerate(PARAPHRASE_CONTROLS, start=1)
+    ),
+)
+
+
+def query_kind_counts(cases: Sequence[QueryCase]) -> dict[str, int]:
+    """Return the number of pinned cases in each query shape."""
+    return dict(Counter(case.kind for case in cases))
+
+
+def _validate_protocol(cases: Sequence[QueryCase]) -> None:
+    if not cases:
+        raise ValueError("at least one query case is required")
+    ids = [case.case_id for case in cases]
+    if len(ids) != len(set(ids)):
+        raise ValueError("query case ids must be unique")
+    for case in cases:
+        if case.kind not in QUERY_KINDS:
+            raise ValueError(f"unsupported query kind: {case.kind}")
+        if not case.query.strip():
+            raise ValueError(f"query case {case.case_id} is empty")
+        if case.kind in ABSENT_KINDS and case.expected_topic is not None:
+            raise ValueError(f"absent case {case.case_id} cannot have a true topic")
+        if case.kind in CONTROL_KINDS and not case.expected_topic:
+            raise ValueError(f"control case {case.case_id} needs a true topic")
+
+
+def _score_stats(values: Sequence[float]) -> dict[str, float] | None:
+    if not values:
+        return None
+    return {
+        "min": min(values),
+        "median": statistics.median(values),
+        "max": max(values),
+    }
+
+
+def summarize_observations(
+    observations: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    """Summarize query-level false positives and answer-present controls."""
+    absent = [row for row in observations if row["kind"] in ABSENT_KINDS]
+    false_positives = [row for row in absent if row["returned_count"] > 0]
+
+    by_kind: dict[str, dict[str, int | float]] = {}
+    for kind in sorted(ABSENT_KINDS):
+        rows = [row for row in absent if row["kind"] == kind]
+        if not rows:
+            continue
+        returned = sum(row["returned_count"] > 0 for row in rows)
+        by_kind[kind] = {
+            "returned": returned,
+            "total": len(rows),
+            "false_positive_rate": returned / len(rows),
+        }
+
+    controls: dict[str, dict[str, int]] = {}
+    for label, kind in (
+        ("exact", "control_exact"),
+        ("paraphrase", "control_paraphrase"),
+    ):
+        rows = [row for row in observations if row["kind"] == kind]
+        controls[label] = {
+            "true_hits": sum(row["true_match"] is True for row in rows),
+            "total": len(rows),
+        }
+
+    returned = len(false_positives)
+    total = len(absent)
+    return {
+        "no_answer": {
+            "returned": returned,
+            "total": total,
+            "false_positive_rate": returned / total if total else 0.0,
+        },
+        "no_answer_by_kind": by_kind,
+        "controls": controls,
+        "false_positive_scores": {
+            "fused": _score_stats(
+                [
+                    float(row["top_score"])
+                    for row in false_positives
+                    if row["top_score"] is not None
+                ]
+            ),
+            "raw": _score_stats(
+                [
+                    float(row["top_raw_score"])
+                    for row in false_positives
+                    if row["top_raw_score"] is not None
+                ]
+            ),
+        },
+    }
+
+
+def _matches_topic(result: dict[str, Any], expected_topic: str) -> bool:
+    return expected_topic.casefold() in str(result.get("content", "")).casefold()
+
+
+def _observation(case: QueryCase, results: list[dict[str, Any]]) -> dict[str, Any]:
+    top = results[0] if results else None
+    true_match_rank: int | None = None
+    best_true_raw_score: float | None = None
+    if case.expected_topic is not None:
+        for rank, result in enumerate(results, start=1):
+            if not _matches_topic(result, case.expected_topic):
+                continue
+            if true_match_rank is None:
+                true_match_rank = rank
+            raw_score = result.get("raw_score")
+            if raw_score is not None:
+                raw_score = float(raw_score)
+                best_true_raw_score = (
+                    raw_score
+                    if best_true_raw_score is None
+                    else max(best_true_raw_score, raw_score)
+                )
+
+    return {
+        "case_id": case.case_id,
+        "kind": case.kind,
+        "query": case.query,
+        "expected_topic": case.expected_topic,
+        "returned_count": len(results),
+        "top_score": float(top["score"]) if top is not None else None,
+        "top_raw_score": (
+            float(top["raw_score"])
+            if top is not None and top.get("raw_score") is not None
+            else None
+        ),
+        "true_match": true_match_rank is not None
+        if case.expected_topic is not None
+        else None,
+        "true_match_rank": true_match_rank,
+        "best_true_raw_score": best_true_raw_score,
+    }
+
+
+def _measure(
+    cases: Sequence[QueryCase],
+    query_vectors: dict[str, list[float]],
+    *,
+    threshold: float,
+    top_k: int,
+    mode: str,
+) -> dict[str, Any]:
+    from palinode.core import store
+
+    use_fts = mode == "hybrid"
+    observations = []
+    for case in cases:
+        results = store.search_hybrid(
+            case.query,
+            query_vectors[case.case_id],
+            top_k=top_k,
+            threshold=threshold,
+            use_fts=use_fts,
+            record_access=False,
+        )
+        observations.append(_observation(case, results))
+    return {
+        "mode": mode,
+        "threshold": threshold,
+        "summary": summarize_observations(observations),
+        "observations": observations,
+    }
+
+
+def _aggregate(
+    runs: Sequence[dict[str, Any]], thresholds: Sequence[float]
+) -> list[dict[str, Any]]:
+    aggregate = []
+    for mode in MODES:
+        for threshold in thresholds:
+            observations = []
+            for run in runs:
+                row = next(
+                    measurement
+                    for measurement in run["measurements"]
+                    if measurement["mode"] == mode
+                    and measurement["threshold"] == threshold
+                )
+                observations.extend(row["observations"])
+            aggregate.append(
+                {
+                    "mode": mode,
+                    "threshold": threshold,
+                    "summary": summarize_observations(observations),
+                }
+            )
+    return aggregate
+
+
+def _package_version() -> str:
+    try:
+        return version("palinode")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def evaluate(
+    *,
+    seeds: Sequence[int] = (1337, 2026, 9001),
+    size: int = 60,
+    thresholds: Sequence[float] = (0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60),
+    top_k: int = 5,
+    cases: Sequence[QueryCase] = DEFAULT_QUERY_CASES,
+) -> dict[str, Any]:
+    """Run the abstention protocol against real embedded SQLite stores."""
+    from palinode.core import embedder
+    from palinode.core.config import config
+
+    seeds = tuple(seeds)
+    thresholds = tuple(float(value) for value in thresholds)
+    cases = tuple(cases)
+    _validate_protocol(cases)
+    if not seeds:
+        raise ValueError("at least one corpus seed is required")
+    if size <= 0:
+        raise ValueError("corpus size must be positive")
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    if not thresholds or any(value < 0.0 or value > 1.0 for value in thresholds):
+        raise ValueError("thresholds must contain values between 0.0 and 1.0")
+    dimensions = int(config.embeddings.primary.dimensions)
+    query_vectors: dict[str, list[float]] = {}
+    try:
+        for case in cases:
+            vector = embedder.embed(case.query)
+            if len(vector) != dimensions:
+                raise RuntimeError(
+                    f"embedder returned {len(vector)} dimensions; expected {dimensions}"
+                )
+            query_vectors[case.case_id] = vector
+    except embedder.EmbeddingUnavailable as exc:
+        raise RuntimeError(
+            "abstention evaluation requires the configured embedding endpoint"
+        ) from exc
+
+    runs = []
+    for seed in seeds:
+        with tempfile.TemporaryDirectory(
+            prefix=f"pnbench-abstention-{seed}-"
+        ) as palinode_dir:
+            harness.point_config_at(palinode_dir)
+            generated = corpus.generate(palinode_dir, seed=seed, size=size)
+            harness.init_store()
+            indexed = harness.index_all(palinode_dir)
+            if indexed.num_facts == 0 or indexed.num_vectors != indexed.num_facts:
+                raise RuntimeError(
+                    "abstention evaluation requires a fully embedded corpus "
+                    f"({indexed.num_vectors}/{indexed.num_facts} chunks embedded)"
+                )
+
+            measurements = []
+            for threshold in thresholds:
+                for mode in MODES:
+                    measurements.append(
+                        _measure(
+                            cases,
+                            query_vectors,
+                            threshold=threshold,
+                            top_k=top_k,
+                            mode=mode,
+                        )
+                    )
+            runs.append(
+                {
+                    "seed": seed,
+                    "num_files": generated.num_files,
+                    "num_chunks": indexed.num_facts,
+                    "measurements": measurements,
+                }
+            )
+
+    results = {
+        "schema_version": 1,
+        "environment": {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "palinode_version": _package_version(),
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+            "embedding_model": config.embeddings.primary.model,
+            "embedding_dimensions": dimensions,
+        },
+        "parameters": {
+            "seeds": list(seeds),
+            "size": size,
+            "thresholds": list(thresholds),
+            "top_k": top_k,
+            "modes": list(MODES),
+            "query_counts": query_kind_counts(cases),
+            "production_defaults_changed": False,
+        },
+        "runs": runs,
+    }
+    results["aggregate"] = _aggregate(runs, thresholds)
+    return results
+
+
+def _ratio(row: dict[str, Any]) -> str:
+    return f"{row['returned']}/{row['total']} ({row['false_positive_rate']:.1%})"
+
+
+def _control_ratio(row: dict[str, Any]) -> str:
+    return f"{row['true_hits']}/{row['total']}"
+
+
+def _format_score_stats(stats: dict[str, float] | None) -> str:
+    if stats is None:
+        return "—"
+    return f"{stats['min']:.3f} / {stats['median']:.3f} / {stats['max']:.3f}"
+
+
+def render_markdown(results: dict[str, Any]) -> str:
+    """Render the aggregate threshold sweep as a reviewable Markdown table."""
+    env = results["environment"]
+    params = results["parameters"]
+    counts = params["query_counts"]
+    lines = [
+        "# Palinode abstention evaluation",
+        "",
+        f"- Generated: {env['generated_at']}",
+        f"- Palinode: {env['palinode_version']}",
+        f"- Embedder: {env['embedding_model']} ({env['embedding_dimensions']} dimensions)",
+        f"- Corpus seeds: {', '.join(str(seed) for seed in params['seeds'])}",
+        f"- Corpus size: {params['size']} files per seed; top-k: {params['top_k']}",
+        "- Query protocol: "
+        f"{sum(counts.get(kind, 0) for kind in ABSENT_KINDS)} no-answer queries "
+        f"and {sum(counts.get(kind, 0) for kind in CONTROL_KINDS)} answer-present controls per seed",
+        "- Production defaults changed: **no**",
+        "",
+        "A false positive is counted once per no-answer query when search returns one or more hits. "
+        "Control recall requires the result set to contain the seeded topic, not merely any hit.",
+        "",
+    ]
+
+    for mode in MODES:
+        lines.extend(
+            [
+                f"## {mode.title()} search",
+                "",
+                "| Threshold | No-answer queries returning a hit | Exact controls with true hit | Paraphrase controls with true hit | False-positive fused score min / median / max | False-positive raw cosine min / median / max |",
+                "|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in results["aggregate"]:
+            if row["mode"] != mode:
+                continue
+            summary = row["summary"]
+            lines.append(
+                f"| {row['threshold']:.2f} "
+                f"| {_ratio(summary['no_answer'])} "
+                f"| {_control_ratio(summary['controls']['exact'])} "
+                f"| {_control_ratio(summary['controls']['paraphrase'])} "
+                f"| {_format_score_stats(summary['false_positive_scores']['fused'])} "
+                f"| {_format_score_stats(summary['false_positive_scores']['raw'])} |"
+            )
+        lines.extend(["", "Scores describe only false-positive result sets.", ""])
+
+    return "\n".join(lines)
+
+
+def _csv_ints(raw: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(item.strip()) for item in raw.split(",") if item.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected comma-separated integers") from exc
+
+
+def _csv_floats(raw: str) -> tuple[float, ...]:
+    try:
+        return tuple(float(item.strip()) for item in raw.split(",") if item.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected comma-separated numbers") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure weak-match abstention without changing search defaults"
+    )
+    parser.add_argument("--seeds", type=_csv_ints, default=(1337, 2026, 9001))
+    parser.add_argument("--size", type=int, default=60)
+    parser.add_argument(
+        "--thresholds",
+        type=_csv_floats,
+        default=(0.30, 0.35, 0.40, 0.45, 0.50, 0.55, 0.60),
+    )
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        results = evaluate(
+            seeds=args.seeds,
+            size=args.size,
+            thresholds=args.thresholds,
+            top_k=args.top_k,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    payload = (
+        render_markdown(results)
+        if args.format == "markdown"
+        else json.dumps(results, indent=2, sort_keys=True)
+    )
+    if args.out is None:
+        print(payload)
+    else:
+        args.out.write_text(payload + "\n", encoding="utf-8")
+        print(f"wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Added
 
+- Standalone `bench.abstention` evaluation for search abstention: a real
+  SQLite-vec + FTS5 threshold sweep across multiple seeded corpora, with
+  no-answer false-positive rates, answer-present controls, and both fused and
+  raw top scores. The evolving protocol remains separate from the stable
+  benchmark runner and does not change production search defaults.
+
 ### Changed
 
 ### Fixed

--- a/tests/test_bench_abstention.py
+++ b/tests/test_bench_abstention.py
@@ -1,0 +1,158 @@
+"""Tests for the standalone abstention evaluation."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bench import abstention
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_config():
+    """Restore process-global store configuration after each evaluation."""
+    from palinode.core import store
+    from palinode.core.config import config
+
+    snapshot = (config.memory_dir, config.db_path, store._db_checked)
+    fresh_db = os.environ.get("PALINODE_ALLOW_FRESH_DB")
+    try:
+        yield
+    finally:
+        config.memory_dir, config.db_path, store._db_checked = snapshot
+        if fresh_db is None:
+            os.environ.pop("PALINODE_ALLOW_FRESH_DB", None)
+        else:
+            os.environ["PALINODE_ALLOW_FRESH_DB"] = fresh_db
+
+
+def test_default_query_protocol_is_pinned():
+    counts = abstention.query_kind_counts(abstention.DEFAULT_QUERY_CASES)
+
+    assert counts == {
+        "absent_natural": 10,
+        "absent_keyword": 10,
+        "absent_identifier": 6,
+        "control_exact": 10,
+        "control_paraphrase": 10,
+    }
+    assert len({case.case_id for case in abstention.DEFAULT_QUERY_CASES}) == 46
+    assert all(
+        case.expected_topic is None
+        for case in abstention.DEFAULT_QUERY_CASES
+        if case.kind.startswith("absent_")
+    )
+
+
+def test_summarize_counts_queries_and_score_ranges():
+    observations = [
+        {
+            "kind": "absent_natural",
+            "returned_count": 2,
+            "top_score": 1.0,
+            "top_raw_score": 0.42,
+            "true_match": None,
+        },
+        {
+            "kind": "absent_keyword",
+            "returned_count": 0,
+            "top_score": None,
+            "top_raw_score": None,
+            "true_match": None,
+        },
+        {
+            "kind": "control_exact",
+            "returned_count": 1,
+            "top_score": 1.0,
+            "top_raw_score": 0.91,
+            "true_match": True,
+        },
+        {
+            "kind": "control_paraphrase",
+            "returned_count": 1,
+            "top_score": 1.0,
+            "top_raw_score": 0.48,
+            "true_match": False,
+        },
+    ]
+
+    summary = abstention.summarize_observations(observations)
+
+    assert summary["no_answer"] == {
+        "returned": 1,
+        "total": 2,
+        "false_positive_rate": 0.5,
+    }
+    assert summary["controls"]["exact"] == {"true_hits": 1, "total": 1}
+    assert summary["controls"]["paraphrase"] == {"true_hits": 0, "total": 1}
+    assert summary["false_positive_scores"]["fused"] == {
+        "min": 1.0,
+        "median": 1.0,
+        "max": 1.0,
+    }
+    assert summary["false_positive_scores"]["raw"] == {
+        "min": 0.42,
+        "median": 0.42,
+        "max": 0.42,
+    }
+
+
+def test_evaluate_runs_real_store_and_preserves_controls(monkeypatch):
+    """The evaluation uses real SQLite while the embedder is deterministic."""
+    from palinode.core.config import config
+
+    dimensions = int(config.embeddings.primary.dimensions)
+    topic = "database migration"
+    paraphrase = "moving persistent data to a new schema"
+
+    def semantic_embed(text: str) -> list[float]:
+        vector = [0.0] * dimensions
+        lowered = text.lower()
+        coordinate = 100
+        for index, corpus_topic in enumerate(abstention.corpus.TOPICS):
+            if corpus_topic in lowered:
+                coordinate = index
+                break
+        if paraphrase in lowered:
+            coordinate = 0
+        vector[coordinate] = 1.0
+        return vector
+
+    monkeypatch.setattr("palinode.core.embedder.embed", semantic_embed)
+    # A short reachability probe can time out while a real configured embed
+    # call still succeeds; the evaluation must trust the actual call.
+    monkeypatch.setattr("bench.harness.embedder_available", lambda: False)
+
+    cases = (
+        abstention.QueryCase("absent", "absent_natural", "missing answer"),
+        abstention.QueryCase("exact", "control_exact", topic, topic),
+        abstention.QueryCase("paraphrase", "control_paraphrase", paraphrase, topic),
+    )
+    results = abstention.evaluate(
+        seeds=(7,),
+        size=10,
+        thresholds=(0.0, 0.5),
+        top_k=5,
+        cases=cases,
+    )
+
+    assert results["parameters"]["query_counts"] == {
+        "absent_natural": 1,
+        "control_exact": 1,
+        "control_paraphrase": 1,
+    }
+    assert results["runs"][0]["num_chunks"] > 0
+    vector_summaries = {
+        row["threshold"]: row["summary"]
+        for row in results["runs"][0]["measurements"]
+        if row["mode"] == "vector"
+    }
+    assert vector_summaries[0.0]["no_answer"]["returned"] == 1
+    assert vector_summaries[0.5]["no_answer"]["returned"] == 0
+    assert vector_summaries[0.5]["controls"]["exact"]["true_hits"] == 1
+    assert vector_summaries[0.5]["controls"]["paraphrase"]["true_hits"] == 1
+
+    report = abstention.render_markdown(results)
+    assert "# Palinode abstention evaluation" in report
+    assert "No-answer queries returning a hit" in report
+    assert "Production defaults changed: **no**" in report

--- a/tests/test_bench_abstention.py
+++ b/tests/test_bench_abstention.py
@@ -153,6 +153,7 @@ def test_evaluate_runs_real_store_and_preserves_controls(monkeypatch):
     assert vector_summaries[0.5]["controls"]["paraphrase"]["true_hits"] == 1
 
     report = abstention.render_markdown(results)
+    report.encode("ascii")
     assert "# Palinode abstention evaluation" in report
     assert "No-answer queries returning a hit" in report
     assert "Production defaults changed: **no**" in report


### PR DESCRIPTION
## Why

Search can return a ranked result even when the seeded store contains no true answer. Measuring only no-answer queries would make it easy to "improve" abstention by suppressing useful recall too, so this evaluation keeps answer-present controls in the same threshold sweep.

Per the issue discussion, this lands as a standalone experiment under `bench/`; it does not couple an evolving protocol to the stable four-axis runner and does not change any production search default.

## What

- pins 26 no-answer queries across three shapes: natural questions, short keywords, and absent identifiers/codes
- pins 20 answer-present controls: 10 exact topics and 10 natural-language paraphrases
- evaluates three deterministic 60-file corpora (seeds 1337, 2026, 9001)
- runs the real configured embedder, SQLite-vec, FTS5, and ranking pipeline; no mocked store
- sweeps per-arm thresholds from 0.30 through 0.60 for top-5 vector-only and hybrid search
- emits full JSON observations plus a compact Markdown aggregate report
- records query-level false-positive rate, true-control recall, fused top score, and raw cosine

## Real BGE-M3 measurement

Environment: Palinode 0.14.0, Python 3.12.12, BGE-M3 (1024 dimensions). Vector-only and hybrid produced identical aggregate rows in this run.

| threshold | no-answer queries returning >=1 hit | exact controls with true hit | paraphrase controls with true hit | false-positive raw cosine min / median / max |
|---:|---:|---:|---:|---:|
| 0.30 | 78/78 | 30/30 | 25/30 | 0.338 / 0.433 / 0.569 |
| 0.35 | 75/78 | 30/30 | 25/30 | 0.356 / 0.436 / 0.569 |
| 0.40 | 62/78 | 30/30 | 25/30 | 0.404 / 0.441 / 0.569 |
| 0.45 | 25/78 | 30/30 | 25/30 | 0.453 / 0.484 / 0.569 |
| 0.50 | 8/78 | 30/30 | 23/30 | 0.513 / 0.518 / 0.569 |
| 0.55 | 3/78 | 30/30 | 18/30 | 0.569 / 0.569 / 0.569 |
| 0.60 | 0/78 | 30/30 | 6/30 | — |

Every false-positive result set exposed a fused top score of `1.0`. The independent reporting problem is already tracked at https://github.com/phasespace-labs/palinode/issues/150; this PR measures it but does not alter score semantics or thresholds.

The result reinforces why controls matter: 0.50 removes most no-answer hits but also loses two paraphrase controls relative to 0.45, and higher floors quickly erase more true paraphrases. This PR therefore proposes no production floor.

## Validation

- `pytest -q`: 3,235 passed, 10 skipped, 5 xfailed
- `pytest tests/test_bench_abstention.py -q`: 3 passed
- `ruff check palinode/ tests/ scripts/`
- `ruff check bench/abstention.py`
- `bandit -r palinode/ -ll`: no medium/high findings

Closes #73