### PR TITLE
test(save): decode and encode save-path files as UTF-8, not the locale default

### DIFF
--- a/tests/test_cold_save_fast_return.py
+++ b/tests/test_cold_save_fast_return.py
@@ -53,7 +53,8 @@ def _write_md(tmp_path) -> str:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(
         "---\nid: cold-save\ncategory: insights\n---\n\n"
-        "Zanzibar swordfish memorandum — distinctive FTS bait text.\n"
+        "Zanzibar swordfish memorandum — distinctive FTS bait text.\n",
+        encoding="utf-8",
     )
     return str(p)
 

--- a/tests/test_save_derived_slug_collision.py
+++ b/tests/test_save_derived_slug_collision.py
@@ -54,7 +54,7 @@ def test_colliding_derived_slugs_do_not_overwrite(mock_memory_dir):
     assert len(set(rel_paths)) == 3, f"expected 3 distinct paths, got {rel_paths}"
 
     for marker, result in zip(markers, results, strict=True):
-        with open(result["file_path"], "r") as fh:
+        with open(result["file_path"], "r", encoding="utf-8") as fh:
             assert marker in fh.read(), f"{marker} was overwritten and is gone"
 
 
@@ -98,7 +98,7 @@ def test_explicit_slug_still_overwrites(mock_memory_dir):
     second = _save("second body", slug="pinned-note")
 
     assert first["rel_path"] == second["rel_path"]
-    with open(second["file_path"], "r") as fh:
+    with open(second["file_path"], "r", encoding="utf-8") as fh:
         body = fh.read()
     assert "second body" in body
     assert "first body" not in body

--- a/tests/test_save_git_committed.py
+++ b/tests/test_save_git_committed.py
@@ -35,7 +35,12 @@ _FAKE_VECTOR = [0.01] * 1024
 
 def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=False,
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+        errors="replace",
     )
 
 
@@ -106,7 +111,7 @@ class TestNotARepo:
     def test_choke_point_outcome(self, memory_dir):
         target = memory_dir / "insights"
         target.mkdir()
-        (target / "x.md").write_text("x\n")
+        (target / "x.md").write_text("x\n", encoding="utf-8")
         outcome = git_tools.try_commit_memory_files([str(target / "x.md")], "m")
         assert outcome.committed is False
         assert outcome.error and "not a git repository" in outcome.error
@@ -158,7 +163,7 @@ class TestHealthyRepo:
 
     def test_index_lock_contention_is_reported(self, memory_dir):
         _init_repo(memory_dir, identity=True)
-        (memory_dir / ".git" / "index.lock").write_text("")
+        (memory_dir / ".git" / "index.lock").write_text("", encoding="utf-8")
         result = _save("locked")
 
         assert result["git_committed"] is False

--- a/tests/test_save_inline_index.py
+++ b/tests/test_save_inline_index.py
@@ -273,7 +273,7 @@ class TestIndexFileVerifiesIndexPresence:
             "---\n\n"
             "Watcher defense-in-depth sentinel.\n"
         )
-        file_path.write_text(md)
+        file_path.write_text(md, encoding="utf-8")
 
         # First pass: full embed.
         with _patch_embed_ok():
@@ -334,7 +334,7 @@ class TestIndexFileVerifiesIndexPresence:
             "---\n\n"
             "Fast-path skip sentinel.\n"
         )
-        file_path.write_text(md)
+        file_path.write_text(md, encoding="utf-8")
 
         with _patch_embed_ok():
             index_file(str(file_path))
@@ -407,7 +407,7 @@ partial embed outage.
             "type: Insight\n"
             "created_at: '2026-06-10T00:00:00+00:00'\n"
             "---\n\n"
-            "Section body that will fail to embed.\n"
+            "Section body that will fail to embed.\n", encoding="utf-8"
         )
         return file_path
 
@@ -454,7 +454,7 @@ partial embed outage.
         file_path.write_text(
             "---\nid: insights-two\ncategory: insights\n---\n\n"
             f"## One\n\nFirst section embeds fine. {filler}\n\n"
-            f"## Two\n\nSecond section will fail. {filler}\n"
+            f"## Two\n\nSecond section will fail. {filler}\n", encoding="utf-8"
         )
 
         call = {"n": 0}

--- a/tests/test_save_project.py
+++ b/tests/test_save_project.py
@@ -29,7 +29,7 @@ def mock_memory_dir(tmp_path):
 
 
 def _frontmatter(file_path: str) -> dict:
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         text = f.read()
     # Frontmatter is between the first two `---` lines.
     parts = text.split("---", 2)

--- a/tests/test_save_wiki_footer.py
+++ b/tests/test_save_wiki_footer.py
@@ -171,7 +171,7 @@ def client(tmp_path, monkeypatch):
 
 def _read_body(file_path: str) -> str:
     """Return the body (everything after the closing frontmatter ---) of a file."""
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         text = f.read()
     parts = text.split("---", 2)
     assert len(parts) >= 3, f"No frontmatter in {file_path}"
@@ -189,7 +189,7 @@ class TestSaveWikiFooterIntegration:
             res = client.post(
                 "/save",
                 json={
-                    "content": "Decided to adopt BGE-M3 for all embeddings.",
+                    "content": "Decided to adopt BGE-M3 — 日本語 embeddings too.",
                     "type": "Decision",
                     "entities": ["project/palinode", "person/alice"],
                 },
@@ -198,6 +198,9 @@ class TestSaveWikiFooterIntegration:
         body = _read_body(res.json()["file_path"])
         assert "## See also" in body
         assert _WIKI_FOOTER_MARKER in body
+        # The saved body is read back through _read_body. Non-ASCII here is
+        # what makes that read's encoding load-bearing rather than decorative.
+        assert "日本語" in body
         assert "[[palinode]]" in body
         assert "[[alice]]" in body
 

--- a/tests/test_utf8_encoding_guard.py
+++ b/tests/test_utf8_encoding_guard.py
@@ -56,6 +56,12 @@ _ALLOWLIST: tuple[tuple[str, str], ...] = (
 _SWEPT_TEST_FILES: tuple[str, ...] = (
     "tests/test_executor.py",
     "tests/test_executor_replace_guard.py",
+    "tests/test_cold_save_fast_return.py",
+    "tests/test_save_derived_slug_collision.py",
+    "tests/test_save_git_committed.py",
+    "tests/test_save_inline_index.py",
+    "tests/test_save_project.py",
+    "tests/test_save_wiki_footer.py",
 )
 
 _TEXT_MODE_TEMPFILE = {"NamedTemporaryFile", "TemporaryFile", "SpooledTemporaryFile"}


### PR DESCRIPTION
Second of the `tests/` areas from #93, following #149. Same failure, different area: these helpers read and write files Palinode itself writes as UTF-8, but name no encoding, so on native Windows they decode as cp1252.

Reproduced on this host with `LC_ALL=C LANG=C PYTHONUTF8=0 PYTHONCOERCECLOCALE=0`, which gives an ASCII stdio encoding and stands in for the Windows default.

Against the unfixed files, under that locale:

```
FAILED tests/test_cold_save_fast_return.py::test_deferred_pass_writes_fts_only_rows_and_never_calls_embedder
FAILED tests/test_cold_save_fast_return.py::test_deferred_rows_converge_to_embedded_on_warm_rerun
FAILED tests/test_cold_save_fast_return.py::test_unchanged_and_indexed_rows_stay_untouched_in_deferred_mode
FAILED tests/test_utf8_encoding_guard.py::test_swept_test_files_name_their_encoding
4 failed, 60 passed
```

With the fix, 64 passed under the same locale.

One caveat on what that actually shows. Only `test_cold_save_fast_return.py` fails at runtime here, because it is the one carrying non-ASCII fixture content. The other five are caught by the guard, not by a failing assertion, so for them this is a regression guard and not a reproduction. They would fail for real on native Windows. I cannot show that from this machine, so I am not claiming it.

The six files join `_SWEPT_TEST_FILES` in `tests/test_utf8_encoding_guard.py`, which #149 added, so a later edit cannot quietly reintroduce a locale-default call into an area already swept.

Full suite on the default locale: 3232 passed, 10 skipped, 5 xfailed. `ruff check palinode/ tests/ scripts/` clean.