### PR TITLE
test(session-end): decode and encode daily and status files as UTF-8

### DIFF
--- a/tests/integration/test_session_end_e2e_l1_l3.py
+++ b/tests/integration/test_session_end_e2e_l1_l3.py
@@ -245,7 +245,7 @@ def test_l2_daily_note_and_project_status_and_individual_file(
 
     # Pre-create the project status file so the CLI's append path runs
     status_path = os.path.join(memory_dir, "projects", "palinode-status.md")
-    with open(status_path, "w") as f:
+    with open(status_path, "w", encoding="utf-8") as f:
         f.write("# palinode status\n")
 
     summary = "L2 test — wrote daily, status, and indexed individual file"
@@ -268,7 +268,7 @@ def test_l2_daily_note_and_project_status_and_individual_file(
     # --- Daily note ------------------------------------------------------
     daily_path = os.path.join(memory_dir, "daily", f"{_today()}.md")
     assert os.path.exists(daily_path), f"daily note not found at {daily_path}"
-    daily_text = open(daily_path).read()
+    daily_text = open(daily_path, encoding="utf-8").read()
     assert "## Session End" in daily_text
     assert summary in daily_text
     assert "Daily append remains the primary path" in daily_text
@@ -277,7 +277,7 @@ def test_l2_daily_note_and_project_status_and_individual_file(
     assert "**Source:** test" in daily_text
 
     # --- Project status --------------------------------------------------
-    status_text = open(status_path).read()
+    status_text = open(status_path, encoding="utf-8").read()
     assert summary[:80] in status_text, "project-status file did not get the new entry"
     assert f"[{_today()}]" in status_text, "status entry must be date-stamped"
 
@@ -287,7 +287,7 @@ def test_l2_daily_note_and_project_status_and_individual_file(
         f"individual file not at {individual_path}; "
         f"projects/ has {os.listdir(os.path.join(memory_dir, 'projects'))}"
     )
-    ind_text = open(individual_path).read()
+    ind_text = open(individual_path, encoding="utf-8").read()
     # Frontmatter must round-trip type, project entity, and the source
     parts = ind_text.split("---", 2)
     fm = yaml.safe_load(parts[1])
@@ -318,7 +318,7 @@ def test_l2_no_project_lands_in_insights(isolated_memory, cli_with_api_redirect,
         f"individual file not at {individual_path}; "
         f"insights/ has {os.listdir(os.path.join(memory_dir, 'insights'))}"
     )
-    ind_text = open(individual_path).read()
+    ind_text = open(individual_path, encoding="utf-8").read()
     fm = yaml.safe_load(ind_text.split("---", 2)[1])
     assert fm["type"] == "Insight"
     assert fm["category"] == "insights"

--- a/tests/test_session_end.py
+++ b/tests/test_session_end.py
@@ -36,7 +36,7 @@ def test_session_end_creates_daily_and_individual(tmp_path, monkeypatch):
         from palinode.api.server import session_end_api, SessionEndRequest
 
         req = SessionEndRequest(
-            summary="Implemented entity normalization",
+            summary="Implemented entity normalization — café, 日本語",
             decisions=["Use category-based prefix inference"],
             blockers=["Need to test with live Ollama"],
             project="palinode",
@@ -48,8 +48,11 @@ def test_session_end_creates_daily_and_individual(tmp_path, monkeypatch):
     daily_file = result["daily_file"]
     daily_path = os.path.join(memory_dir, daily_file)
     assert os.path.exists(daily_path), f"Daily file not found: {daily_path}"
-    daily_content = open(daily_path).read()
+    daily_content = open(daily_path, encoding="utf-8").read()
     assert "Implemented entity normalization" in daily_content
+    # The daily note is written by Palinode as UTF-8 and read back here. Non-ASCII
+    # in the summary is what makes this read's encoding load-bearing.
+    assert "日本語" in daily_content
 
     # Individual file should exist
     individual_file = result.get("individual_file")
@@ -57,7 +60,7 @@ def test_session_end_creates_daily_and_individual(tmp_path, monkeypatch):
     assert os.path.exists(individual_file), f"Individual file not found: {individual_file}"
 
     # Individual file should have frontmatter with entities
-    ind_content = open(individual_file).read()
+    ind_content = open(individual_file, encoding="utf-8").read()
     assert "project/palinode" in ind_content
     # the auto-description is no longer written inline on save — it is
     # deferred to the watcher-driven /generate-summaries backfill, so the file
@@ -86,7 +89,7 @@ def test_session_end_no_project(tmp_path, monkeypatch):
     assert os.path.exists(individual_file)
 
     # Should be in insights/ category (Insight type)
-    ind_content = open(individual_file).read()
+    ind_content = open(individual_file, encoding="utf-8").read()
     assert "category: insights" in ind_content
 
 
@@ -130,7 +133,7 @@ def test_session_end_with_full_metadata(tmp_path, monkeypatch):
         result = session_end_api(req)
 
     daily_path = os.path.join(memory_dir, result["daily_file"])
-    daily = open(daily_path).read()
+    daily = open(daily_path, encoding="utf-8").read()
     # Daily note should carry all six metadata lines
     assert "**Harness:** claude-code" in daily
     assert "**CWD:** /Users/alice/Code/my-project" in daily
@@ -140,7 +143,7 @@ def test_session_end_with_full_metadata(tmp_path, monkeypatch):
     assert "**Duration:** 4837s" in daily
 
     ind_path = result["individual_file"]
-    ind = open(ind_path).read()
+    ind = open(ind_path, encoding="utf-8").read()
     # Frontmatter should carry the metadata as structured fields
     assert "harness: claude-code" in ind
     assert "model: claude-opus-4-7" in ind
@@ -162,7 +165,7 @@ def test_session_end_without_metadata_keeps_daily_clean(tmp_path, monkeypatch):
         req = SessionEndRequest(summary="No metadata", source="test")
         result = session_end_api(req)
 
-    daily = open(os.path.join(memory_dir, result["daily_file"])).read()
+    daily = open(os.path.join(memory_dir, result["daily_file"]), encoding="utf-8").read()
     for marker in ("**Harness:**", "**CWD:**", "**Model:**",
                    "**Trigger:**", "**Session ID:**", "**Duration:**"):
         assert marker not in daily, f"unexpected metadata line: {marker}"
@@ -180,7 +183,7 @@ def test_session_end_auto_derives_project_from_cwd(tmp_path, monkeypatch):
     projects_dir = os.path.join(memory_dir, "projects")
     os.makedirs(projects_dir)
     status_path = os.path.join(projects_dir, "my-project-status.md")
-    with open(status_path, "w") as f:
+    with open(status_path, "w", encoding="utf-8") as f:
         f.write("# my-project status\n")
 
     with mock.patch("palinode.api.server._generate_description", return_value="Auto-derive"):
@@ -195,7 +198,7 @@ def test_session_end_auto_derives_project_from_cwd(tmp_path, monkeypatch):
 
     # status_file should be set and reference the auto-derived slug
     assert result.get("status_file") == "projects/my-project-status.md"
-    status = open(status_path).read()
+    status = open(status_path, encoding="utf-8").read()
     assert "cwd auto-derivation works" in status
 
     # Individual file's slug should embed the auto-derived project too
@@ -296,7 +299,7 @@ def test_session_end_date_is_wallclock_not_existing_files(tmp_path, monkeypatch)
     os.makedirs(daily_dir, exist_ok=True)
     stale_path = os.path.join(daily_dir, "2020-01-01.md")
     stale_original = "## Session End — 2020-01-01T00:00:00Z\nold entry\n"
-    with open(stale_path, "w") as f:
+    with open(stale_path, "w", encoding="utf-8") as f:
         f.write(stale_original)
 
     # Freeze wall-clock to a fixed instant, distinct from both today and the stale file.
@@ -317,4 +320,4 @@ def test_session_end_date_is_wallclock_not_existing_files(tmp_path, monkeypatch)
     assert os.path.exists(os.path.join(memory_dir, "daily", "2030-06-15.md"))
     assert "## Session End — 2030-06-15T12:00:00Z" in result["entry"]
     # The pre-existing stale file must be untouched (never appended to).
-    assert open(stale_path).read() == stale_original
+    assert open(stale_path, encoding="utf-8").read() == stale_original

--- a/tests/test_session_end_dedup.py
+++ b/tests/test_session_end_dedup.py
@@ -63,7 +63,7 @@ def _index_prior_save(
     file and (optionally) backdate it via ``os.utime``.
     """
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         f.write(content)
     if mtime is not None:
         ts = mtime.timestamp()
@@ -161,7 +161,7 @@ def test_above_threshold_skips_individual_file(_isolated_env):
 
     # Pre-create the project status file so we can verify its append still happens
     status_path = os.path.join(memory_dir, "projects", "palinode-status.md")
-    with open(status_path, "w") as f:
+    with open(status_path, "w", encoding="utf-8") as f:
         f.write("# palinode status\n")
 
     with (
@@ -185,9 +185,9 @@ def test_above_threshold_skips_individual_file(_isolated_env):
     # Daily note still appended
     daily_path = os.path.join(memory_dir, result["daily_file"])
     assert os.path.exists(daily_path)
-    assert "Same content, reformatted" in open(daily_path).read()
+    assert "Same content, reformatted" in open(daily_path, encoding="utf-8").read()
     # Project status file still appended
-    status_text = open(status_path).read()
+    status_text = open(status_path, encoding="utf-8").read()
     assert "Same content, reformatted" in status_text
 
 

--- a/tests/test_session_end_envelope_guard.py
+++ b/tests/test_session_end_envelope_guard.py
@@ -121,7 +121,7 @@ def test_rejection_writes_nothing_at_all(tmp_path, monkeypatch):
     half-captured session behind in the daily note or the status file."""
     os.makedirs(os.path.join(str(tmp_path), "projects"))
     status_path = os.path.join(str(tmp_path), "projects", "palinode-status.md")
-    with open(status_path, "w") as f:
+    with open(status_path, "w", encoding="utf-8") as f:
         f.write("# palinode status\n")
 
     with pytest.raises(HTTPException):
@@ -129,7 +129,7 @@ def test_rejection_writes_nothing_at_all(tmp_path, monkeypatch):
               summary="Broken</decisions>", project="palinode")
 
     assert not os.path.exists(os.path.join(str(tmp_path), "daily"))
-    assert open(status_path).read() == "# palinode status\n"
+    assert open(status_path, encoding="utf-8").read() == "# palinode status\n"
 
 
 def test_wire_level_400_carries_the_detail(tmp_path, monkeypatch):
@@ -376,7 +376,8 @@ def _run_hook(tmp_path: Path, transcript: str) -> dict:
 
     env = dict(os.environ, PALINODE_HOOK_DRYRUN="1")
     proc = subprocess.run(["bash", str(HOOK)], input=stdin,
-                          capture_output=True, text=True, env=env)
+                          capture_output=True, text=True, env=env,
+                          encoding="utf-8", errors="replace")
     assert proc.returncode == 0, f"hook must exit 0; got {proc.returncode}: {proc.stderr}"
     body = proc.stdout.split("\n", 1)[1]
     return json.loads(body)
@@ -438,7 +439,7 @@ def test_dry_run_writes_absolutely_nothing(tmp_path, monkeypatch):
     record to do it — twice, in practice."""
     os.makedirs(os.path.join(str(tmp_path), "projects"))
     status_path = os.path.join(str(tmp_path), "projects", "palinode-status.md")
-    with open(status_path, "w") as f:
+    with open(status_path, "w", encoding="utf-8") as f:
         f.write("# palinode status\n")
 
     result = _dry(tmp_path, monkeypatch, summary="A perfectly valid summary",
@@ -448,7 +449,7 @@ def test_dry_run_writes_absolutely_nothing(tmp_path, monkeypatch):
     assert result["committed"] is False and result["pushed"] is False
     # Nothing on disk moved.
     assert not os.path.exists(os.path.join(str(tmp_path), "daily"))
-    assert open(status_path).read() == "# palinode status\n"
+    assert open(status_path, encoding="utf-8").read() == "# palinode status\n"
 
 
 def test_dry_run_renders_the_entry_it_would_write(tmp_path, monkeypatch):
@@ -478,7 +479,7 @@ def test_dry_run_reports_status_file_only_when_it_exists(tmp_path, monkeypatch):
     assert absent["status_file"] is None
 
     os.makedirs(os.path.join(str(tmp_path), "projects"), exist_ok=True)
-    with open(os.path.join(str(tmp_path), "projects", "palinode-status.md"), "w") as f:
+    with open(os.path.join(str(tmp_path), "projects", "palinode-status.md"), "w", encoding="utf-8") as f:
         f.write("# palinode status\n")
     present = _dry(tmp_path, monkeypatch, summary="s", project="palinode")
     assert present["status_file"] == "projects/palinode-status.md"

--- a/tests/test_session_end_floor_hook.py
+++ b/tests/test_session_end_floor_hook.py
@@ -55,7 +55,13 @@ def _run(tmp_path: Path, transcript_body: str, extra_env: dict | None = None) ->
     if extra_env:
         env.update(extra_env)
     proc = subprocess.run(
-        ["bash", str(HOOK)], input=payload, capture_output=True, text=True, env=env
+        ["bash", str(HOOK)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        encoding="utf-8",
+        errors="replace",
     )
     assert proc.returncode == 0, f"hook must always exit 0; got {proc.returncode}: {proc.stderr}"
     return proc.stdout

--- a/tests/test_session_end_status_line.py
+++ b/tests/test_session_end_status_line.py
@@ -52,7 +52,7 @@ def _run_session_end(tmp_path, monkeypatch, **kwargs):
     projects_dir = os.path.join(memory_dir, "projects")
     os.makedirs(projects_dir, exist_ok=True)
     status_path = os.path.join(projects_dir, "palinode-status.md")
-    with open(status_path, "w") as f:
+    with open(status_path, "w", encoding="utf-8") as f:
         f.write("# palinode status\n")
 
     with mock.patch("palinode.api.routers.session._check_session_end_dedup",
@@ -63,7 +63,7 @@ def _run_session_end(tmp_path, monkeypatch, **kwargs):
         kwargs.setdefault("source", "test")
         result = session_end_api(SessionEndRequest(**kwargs))
 
-    return result, open(status_path).read()
+    return result, open(status_path, encoding="utf-8").read()
 
 
 def _last_status_line(status_text: str) -> str:
@@ -88,11 +88,11 @@ def test_arrays_survive_to_every_writer(tmp_path, monkeypatch):
         blockers=blockers,
     )
 
-    daily = open(os.path.join(str(tmp_path), result["daily_file"])).read()
+    daily = open(os.path.join(str(tmp_path), result["daily_file"]), encoding="utf-8").read()
     for entry in decisions + blockers:
         assert entry in daily, f"daily note lost {entry!r}"
 
-    individual = open(result["individual_file"]).read()
+    individual = open(result["individual_file"], encoding="utf-8").read()
     for entry in decisions + blockers:
         assert entry in individual, f"indexed file lost {entry!r}"
 
@@ -127,7 +127,7 @@ def test_status_line_falls_back_to_daily_when_no_indexed_file(tmp_path, monkeypa
     monkeypatch.setattr(config.git, "auto_commit", False)
     os.makedirs(os.path.join(memory_dir, "projects"), exist_ok=True)
     status_path = os.path.join(memory_dir, "projects", "palinode-status.md")
-    with open(status_path, "w") as f:
+    with open(status_path, "w", encoding="utf-8") as f:
         f.write("# palinode status\n")
 
     with mock.patch("palinode.api.routers.session._check_session_end_dedup",
@@ -140,7 +140,7 @@ def test_status_line_falls_back_to_daily_when_no_indexed_file(tmp_path, monkeypa
         ))
 
     assert result["individual_file"] is None
-    line = _last_status_line(open(status_path).read())
+    line = _last_status_line(open(status_path, encoding="utf-8").read())
     assert result["daily_file"] in line, line
 
 

--- a/tests/test_session_end_timeout.py
+++ b/tests/test_session_end_timeout.py
@@ -120,7 +120,7 @@ def test_hook_script_uses_hook_timeout_variable():
     """examples/hooks/palinode-session-end.sh must use ${HOOK_TIMEOUT} in curl."""
     hook = REPO_ROOT / "examples" / "hooks" / "palinode-session-end.sh"
     assert hook.exists(), f"Hook not found: {hook}"
-    source = hook.read_text()
+    source = hook.read_text(encoding="utf-8")
     # Must set HOOK_TIMEOUT from env with a default
     assert re.search(r'HOOK_TIMEOUT=.*PALINODE_HOOK_TIMEOUT', source), (
         "Hook must set HOOK_TIMEOUT from PALINODE_HOOK_TIMEOUT env var"
@@ -138,14 +138,14 @@ def test_hook_script_default_is_less_than_runner_timeout():
     kills it, giving the || true a chance to run.
     """
     hook = REPO_ROOT / "examples" / "hooks" / "palinode-session-end.sh"
-    source = hook.read_text()
+    source = hook.read_text(encoding="utf-8")
     # Extract the default from HOOK_TIMEOUT="${PALINODE_HOOK_TIMEOUT:-N}"
     match = re.search(r'HOOK_TIMEOUT=.*:-(\d+)', source)
     assert match, "Could not find HOOK_TIMEOUT default in hook script"
     hook_default = int(match.group(1))
 
     settings = REPO_ROOT / "examples" / "hooks" / "settings.json"
-    runner_timeout = json.loads(settings.read_text())["hooks"]["SessionEnd"][0]["hooks"][0]["timeout"]
+    runner_timeout = json.loads(settings.read_text(encoding="utf-8"))["hooks"]["SessionEnd"][0]["hooks"][0]["timeout"]
 
     assert hook_default < runner_timeout, (
         f"Hook curl default ({hook_default}s) must be < runner timeout ({runner_timeout}s) "
@@ -159,7 +159,7 @@ def test_hook_script_default_is_less_than_runner_timeout():
 def test_init_py_hook_mirrors_canonical_hook():
     """palinode/cli/init.py HOOK_SCRIPT must use ${HOOK_TIMEOUT} (not hardcoded)."""
     init_py = REPO_ROOT / "palinode" / "cli" / "init.py"
-    source = init_py.read_text()
+    source = init_py.read_text(encoding="utf-8")
     # Find the HOOK_SCRIPT string literal block
     assert "PALINODE_HOOK_TIMEOUT" in source, (
         "init.py HOOK_SCRIPT must reference PALINODE_HOOK_TIMEOUT (#377)"
@@ -172,7 +172,7 @@ def test_init_py_hook_mirrors_canonical_hook():
 def test_init_py_settings_timeout_matches_canonical():
     """palinode/cli/init.py SETTINGS_HOOK_BLOCK timeout must match examples/hooks/settings.json."""
     settings = REPO_ROOT / "examples" / "hooks" / "settings.json"
-    canonical_timeout = json.loads(settings.read_text())["hooks"]["SessionEnd"][0]["hooks"][0]["timeout"]
+    canonical_timeout = json.loads(settings.read_text(encoding="utf-8"))["hooks"]["SessionEnd"][0]["hooks"][0]["timeout"]
 
     # Extract from init.py via import
     sys.path.insert(0, str(REPO_ROOT))
@@ -198,7 +198,7 @@ def test_hook_script_byte_identical_to_canonical():
     from palinode.cli.init import HOOK_SCRIPT
 
     canonical = REPO_ROOT / "examples" / "hooks" / "palinode-session-end.sh"
-    assert HOOK_SCRIPT == canonical.read_text(), (
+    assert HOOK_SCRIPT == canonical.read_text(encoding="utf-8"), (
         "palinode/cli/init.py HOOK_SCRIPT has drifted from "
         "examples/hooks/palinode-session-end.sh — re-sync them byte-for-byte."
     )

--- a/tests/test_utf8_encoding_guard.py
+++ b/tests/test_utf8_encoding_guard.py
@@ -62,6 +62,13 @@ _SWEPT_TEST_FILES: tuple[str, ...] = (
     "tests/test_save_inline_index.py",
     "tests/test_save_project.py",
     "tests/test_save_wiki_footer.py",
+    "tests/test_session_end.py",
+    "tests/test_session_end_dedup.py",
+    "tests/test_session_end_envelope_guard.py",
+    "tests/test_session_end_floor_hook.py",
+    "tests/test_session_end_status_line.py",
+    "tests/test_session_end_timeout.py",
+    "tests/integration/test_session_end_e2e_l1_l3.py",
 )
 
 _TEXT_MODE_TEMPFILE = {"NamedTemporaryFile", "TemporaryFile", "SpooledTemporaryFile"}


### PR DESCRIPTION
Third of the `tests/` areas from #93, following #149 and #152. Session-end helpers read and write files Palinode wrote as UTF-8 but name no encoding, so on native Windows they decode as cp1252.

Reproduced on this host with `LC_ALL=C LANG=C PYTHONUTF8=0 PYTHONCOERCECLOCALE=0`, which gives an ASCII stdio encoding and stands in for the Windows default.

The six unit files plus the guard:

```
main    16 failed, 62 passed, 4 skipped
branch  78 passed, 4 skipped
```

`tests/integration/test_session_end_e2e_l1_l3.py` run on its own:

```
main    2 failed, 3 passed
branch  5 passed
```

Unlike the last area, these are real runtime failures rather than guard catches. The session-end path writes a daily note and a status file and reads them back in the same test, so an ASCII locale breaks the round trip outright.

One thing worth knowing, which is not from this change. Running the six unit files and the integration file in one pytest session fails 5 integration tests. That happens on a clean checkout of `main` under the default locale too, so it is pre-existing ordering interference between those files and has nothing to do with encoding. The numbers above are measured with the integration file run on its own, which is where its failures are real.

All seven files join `_SWEPT_TEST_FILES`, so a later edit that drops an encoding in an area already swept gets caught.

Full suite on the default locale: 3232 passed, 10 skipped, 5 xfailed. `ruff check palinode/ tests/ scripts/` clean.

On your note from #152: no site in this diff puts `encoding="utf-8"` on a line closing a multi-line call. Every one is a single-line `open(...)`.

That leaves the archive-history area on #93.