### PR TITLE
fix(cli): exit non-zero when stop fails

### DIFF
--- a/palinode/cli/__init__.py
+++ b/palinode/cli/__init__.py
@@ -193,7 +193,7 @@ def stop(watcher, api):
     
     if not shutil.which("systemctl"):
         console.print("[red]Error: 'systemctl' not found. This command requires systemd (Linux).[/red]")
-        raise click.exceptions.Exit(1)
+        raise SystemExit(1)
         
     services = []
     if api:
@@ -215,7 +215,7 @@ def stop(watcher, api):
             console.print(f"[red]✗ Failed to stop {svc}: {e}[/red]")
 
     if failed:
-        raise click.exceptions.Exit(1)
+        raise SystemExit(1)
 
 @main.group()
 def config_cmd():

--- a/palinode/cli/__init__.py
+++ b/palinode/cli/__init__.py
@@ -193,7 +193,7 @@ def stop(watcher, api):
     
     if not shutil.which("systemctl"):
         console.print("[red]Error: 'systemctl' not found. This command requires systemd (Linux).[/red]")
-        return
+        raise click.exceptions.Exit(1)
         
     services = []
     if api:
@@ -204,13 +204,18 @@ def stop(watcher, api):
     if not services:
         return
         
+    failed = False
     for svc in services:
         console.print(f"[yellow]Stopping {svc}...[/yellow]")
         try:
             subprocess.run(["sudo", "systemctl", "stop", svc], check=True)
             console.print(f"[green]✓ {svc} stopped.[/green]")
         except subprocess.CalledProcessError as e:
+            failed = True
             console.print(f"[red]✗ Failed to stop {svc}: {e}[/red]")
+
+    if failed:
+        raise click.exceptions.Exit(1)
 
 @main.group()
 def config_cmd():

--- a/tests/test_cli_stop.py
+++ b/tests/test_cli_stop.py
@@ -1,0 +1,41 @@
+import subprocess
+
+from click.testing import CliRunner
+
+from palinode.cli import main
+
+
+def test_stop_without_systemctl_exits_nonzero(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: None)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["stop"])
+
+    assert result.exit_code != 0
+    assert "systemctl" in result.output
+
+
+def test_stop_success_exits_zero(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/systemctl")
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: None)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["stop"])
+
+    assert result.exit_code == 0
+    assert "stopped" in result.output
+
+
+def test_stop_systemctl_failure_exits_nonzero(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/systemctl")
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0])
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["stop"])
+
+    assert result.exit_code != 0
+    assert "Failed to stop" in result.output

--- a/tests/test_cli_stop.py
+++ b/tests/test_cli_stop.py
@@ -39,3 +39,23 @@ def test_stop_systemctl_failure_exits_nonzero(monkeypatch):
 
     assert result.exit_code != 0
     assert "Failed to stop" in result.output
+
+
+def test_stop_continues_with_remaining_services_after_failure(monkeypatch):
+    """A failed service must not prevent the remaining services from being stopped."""
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/systemctl")
+
+    def fake_run(args, check=True):
+        # palinode-api.service is stopped first; make only it fail.
+        if "api" in args[-1]:
+            raise subprocess.CalledProcessError(1, args)
+        return None
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["stop"])
+
+    assert result.exit_code != 0
+    assert "Failed to stop palinode-api.service" in result.output
+    assert "✓ palinode-watcher.service stopped" in result.output


### PR DESCRIPTION
## Problem

Fixes #155 — `palinode stop` reported failures but always exited 0:

1. **No systemd:** if `systemctl` is not on PATH it prints `Error: 'systemctl' not found...` and returns → exit code 0.
2. **systemctl failed:** the per-service loop catches `subprocess.CalledProcessError`, prints `✗ Failed to stop <svc>`, and continues → exit code 0.

So a script checking `$?` after `palinode stop` cannot tell that services are still running.

## Fix

`palinode/cli/__init__.py` (`stop` command):

- missing `systemctl` → `raise click.exceptions.Exit(1)` instead of a plain `return`
- track whether any `systemctl stop` failed; after the per-service loop, exit 1 if so (the loop still attempts to stop the remaining services, preserving current behavior)

## Tests

New `tests/test_cli_stop.py` (3 tests, `CliRunner` + monkeypatch, matching the style of `tests/test_cli_start.py`):

- no `systemctl` on PATH → non-zero exit + error message
- successful stop → exit 0
- `systemctl stop` raises `CalledProcessError` → non-zero exit + `Failed to stop` message

Verified: the 2 failure-path tests fail against the pre-fix code and pass with it. Existing `test_cli_start.py` + `test_cli_json_output.py` still pass (11 tests). `ruff check` clean on both changed files.

## Limitations

- The failure path for `sudo` prompting/credential errors is out of scope (still surfaces as `CalledProcessError` and now exits non-zero).
- Exit code is 1 in all failure cases; no distinction between "systemctl missing" and "service failed" (the messages differ, which is enough for humans; scripts only need the boolean).