### PR TITLE
fix: align MCP release metadata

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- MCP Registry release metadata now stays aligned with the package version and
+  links to the current release notes.
+
 ### Removed
 
 ### Security

--- a/server.json
+++ b/server.json
@@ -127,8 +127,8 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "tool": "mcp-publisher",
-      "release": "v0.13.0",
-      "release_notes_url": "https://github.com/phasespace-labs/palinode/releases/tag/v0.13.0"
+      "release": "v0.14.0",
+      "release_notes_url": "https://github.com/phasespace-labs/palinode/releases/tag/v0.14.0"
     }
   }
 }

--- a/tests/test_server_json_version_alignment.py
+++ b/tests/test_server_json_version_alignment.py
@@ -122,6 +122,17 @@ def test_server_json_package_versions_match_pyproject():
         )
 
 
+def test_server_json_release_metadata_matches_pyproject():
+    """Publisher-provided release metadata must name the canonical release."""
+    version = _registry_version(_load_pyproject_version())
+    metadata = _load_server_json()["_meta"][
+        "io.modelcontextprotocol.registry/publisher-provided"
+    ]
+
+    assert metadata["release"] == f"v{version}"
+    assert metadata["release_notes_url"].endswith(f"/releases/tag/v{version}")
+
+
 def test_server_json_is_valid_json():
     """server.json must be parseable JSON — a corrupt file means no version check fires.
 


### PR DESCRIPTION
Fixes #163

The MCP Registry manifest advertised version 0.14.0 but its publisher-provided metadata linked to the previous release. This updates both metadata fields and extends the existing version-alignment guard so future release drift fails CI.

The unreleased changelog now records the fix.

Tests:
- 3242 passed, 8 skipped, 5 xfailed
- ruff check palinode/ tests/ scripts/
- bandit -r palinode/ -ll