### PR TITLE
fix(cli): exit non-zero on red error paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- CLI commands that printed a red error and then returned now exit non-zero
+  (`raise SystemExit(1)`), so automation can detect failure. Left alone: the
+  yellow "reindex already running" (HTTP 409) path, which is informational.
 - MCP Registry release metadata now stays aligned with the package version and
   links to the current release notes.
 

--- a/palinode/cli/__init__.py
+++ b/palinode/cli/__init__.py
@@ -274,13 +274,14 @@ def config_edit():
         config_file = os.path.join(config.memory_dir, "palinode.config.yaml")
         if not os.path.exists(config_file):
              console.print("[red]Error: Config file not found at default locations.[/red]")
-             return
-             
+             raise SystemExit(1)
+
     editor = os.environ.get("EDITOR", "vi")
     try:
         subprocess.run([editor, config_file], check=True)
     except Exception as e:
         console.print(f"[red]Error opening editor: {e}[/red]")
+        raise SystemExit(1)
 
 main.add_command(config_cmd, name="config")
 

--- a/palinode/cli/depends.py
+++ b/palinode/cli/depends.py
@@ -41,6 +41,7 @@ def depends(slug, unblocked, fmt):
                     console.print(f"  [cyan]{item['slug']}[/cyan]{status_str}")
         except Exception as e:
             console.print(f"[red]Error fetching unblocked items: {e}[/red]")
+            raise SystemExit(1)
         return
 
     if not unblocked and not slug:
@@ -83,3 +84,4 @@ def depends(slug, unblocked, fmt):
 
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
+        raise SystemExit(1)

--- a/palinode/cli/git.py
+++ b/palinode/cli/git.py
@@ -33,6 +33,7 @@ def blame(file_path, search, claims):
             console.print(data)
     except Exception as e:
         console.print(f"[red]Error blaming: {str(e)}[/red]")
+        raise SystemExit(1)
 
 @click.command()
 @click.argument("file_path")
@@ -54,6 +55,7 @@ def history(file_path, limit, detail):
         print_result(data, fmt=get_default_format())
     except Exception as e:
         console.print(f"[red]Error showing history: {str(e)}[/red]")
+        raise SystemExit(1)
 
 
 @click.command()
@@ -77,6 +79,7 @@ def rollback(file_path, commit, dry_run):
         console.print(data)
     except Exception as e:
         console.print(f"[red]Error rolling back: {str(e)}[/red]")
+        raise SystemExit(1)
 
 @click.command()
 def push():
@@ -86,3 +89,4 @@ def push():
         console.print(data)
     except Exception as e:
         console.print(f"[red]Error pushing: {str(e)}[/red]")
+        raise SystemExit(1)

--- a/palinode/cli/ingest.py
+++ b/palinode/cli/ingest.py
@@ -42,5 +42,7 @@ def ingest(url, name, inbox, fmt):
         except Exception:
             pass
         console.print(f"[red]Error:[/red] {detail or e.response.status_code}")
+        raise SystemExit(1)
     except RequestError as e:
         console.print(f"[red]Error:[/red] Cannot reach API — is palinode running? ({e})")
+        raise SystemExit(1)

--- a/palinode/cli/lint.py
+++ b/palinode/cli/lint.py
@@ -44,7 +44,7 @@ def lint(fmt, deep_contradictions, max_llm_calls, similarity_threshold):
         data = api_client.lint()
     except HTTPStatusError as e:
         console.print(f"[red]Error: API returned {e.response.status_code}[/red]")
-        return
+        raise SystemExit(1)
     except RequestError:
         # Fallback to local import if API is down
         from palinode.core.lint import run_lint_pass
@@ -277,7 +277,7 @@ def _run_deep_contradictions_output(
         )
     except Exception as exc:
         console.print(f"[red]Deep contradiction check failed: {exc}[/red]")
-        return
+        raise SystemExit(1)
 
     decisions = result["decisions_found"]
     candidates = result["candidate_pairs"]

--- a/palinode/cli/manage.py
+++ b/palinode/cli/manage.py
@@ -14,8 +14,10 @@ def reindex(fmt):
             console.print("[yellow]Reindex already running. Check 'palinode status' for progress.[/yellow]")
         else:
             console.print(f"[red]Error reindexing: {str(e)}[/red]")
+            raise SystemExit(1)
     except Exception as e:
         console.print(f"[red]Error reindexing: {str(e)}[/red]")
+        raise SystemExit(1)
 
 @click.command(name="rebuild-fts")
 @click.option("--format", "fmt", type=click.Choice(["json", "text"]), help="Output format")
@@ -26,6 +28,7 @@ def rebuild_fts(fmt):
         print_result(result, fmt=OutputFormat(fmt) if fmt else get_default_format())
     except Exception as e:
         console.print(f"[red]Error rebuilding FTS: {str(e)}[/red]")
+        raise SystemExit(1)
 
 @click.command(name="split-layers")
 @click.option("--format", "fmt", type=click.Choice(["json", "text"]), help="Output format")
@@ -36,6 +39,7 @@ def split_layers(fmt):
         print_result(result, fmt=OutputFormat(fmt) if fmt else get_default_format())
     except Exception as e:
         console.print(f"[red]Error splitting layers: {str(e)}[/red]")
+        raise SystemExit(1)
 
 @click.command(name="bootstrap-ids")
 @click.option("--format", "fmt", type=click.Choice(["json", "text"]), help="Output format")
@@ -46,3 +50,4 @@ def bootstrap_ids(fmt):
         print_result(result, fmt=OutputFormat(fmt) if fmt else get_default_format())
     except Exception as e:
         console.print(f"[red]Error bootstrapping IDs: {str(e)}[/red]")
+        raise SystemExit(1)

--- a/palinode/cli/prime.py
+++ b/palinode/cli/prime.py
@@ -42,3 +42,4 @@ def prime(cwd, project, fmt):
             console.print(format_context_digest(data), markup=False)
     except Exception as e:
         console.print(f"[red]Error priming context: {str(e)}[/red]")
+        raise SystemExit(1)

--- a/palinode/cli/query.py
+++ b/palinode/cli/query.py
@@ -12,3 +12,4 @@ def entities(entity, fmt):
         print_result(data, fmt=OutputFormat(fmt) if fmt else get_default_format())
     except Exception as e:
         console.print(f"[red]Error showing entities: {str(e)}[/red]")
+        raise SystemExit(1)

--- a/palinode/cli/trace.py
+++ b/palinode/cli/trace.py
@@ -29,7 +29,7 @@ def trace(file_path, fmt):
         data = api_client.trace(file_path)
     except Exception as e:
         console.print(f"[red]Error tracing: {str(e)}[/red]")
-        return
+        raise SystemExit(1)
 
     if output_fmt == OutputFormat.JSON:
         # click.echo (not console.print): machine-readable JSON must not pass

--- a/tests/test_cli_error_exit_codes.py
+++ b/tests/test_cli_error_exit_codes.py
@@ -1,0 +1,149 @@
+"""CLI error paths must exit non-zero (https://github.com/phasespace-labs/palinode/issues/164)."""
+
+import importlib
+from unittest.mock import patch
+
+import httpx
+from click.testing import CliRunner
+
+from palinode.cli import main
+from palinode.cli._api import HTTPStatusError, RequestError
+
+# importlib: cli/__init__.py re-exports Commands that shadow same-named modules.
+depends_mod = importlib.import_module("palinode.cli.depends")
+git_mod = importlib.import_module("palinode.cli.git")
+ingest_mod = importlib.import_module("palinode.cli.ingest")
+lint_mod = importlib.import_module("palinode.cli.lint")
+manage_mod = importlib.import_module("palinode.cli.manage")
+prime_mod = importlib.import_module("palinode.cli.prime")
+query_mod = importlib.import_module("palinode.cli.query")
+trace_mod = importlib.import_module("palinode.cli.trace")
+
+
+def _http_status_error(status_code: int = 500) -> HTTPStatusError:
+    request = httpx.Request("GET", "http://localhost/test")
+    response = httpx.Response(status_code, request=request)
+    return HTTPStatusError("error", request=request, response=response)
+
+
+def test_depends_unblocked_error_exits_nonzero():
+    with patch.object(
+        depends_mod.api_client, "depends_unblocked", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["depends", "--unblocked"])
+    assert result.exit_code != 0
+    assert "Error fetching unblocked items" in result.output
+
+
+def test_depends_slug_error_exits_nonzero():
+    with patch.object(
+        depends_mod.api_client, "depends", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["depends", "milestone/M1"])
+    assert result.exit_code != 0
+    assert "Error:" in result.output
+
+
+def test_lint_api_status_error_exits_nonzero():
+    with patch.object(
+        lint_mod.api_client, "lint", side_effect=_http_status_error(503)
+    ):
+        result = CliRunner().invoke(main, ["lint"])
+    assert result.exit_code != 0
+    assert "API returned 503" in result.output
+
+
+def test_trace_error_exits_nonzero():
+    with patch.object(
+        trace_mod.api_client, "trace", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["trace", "decisions/x.md"])
+    assert result.exit_code != 0
+    assert "Error tracing" in result.output
+
+
+def test_blame_error_exits_nonzero():
+    with patch.object(
+        git_mod.api_client, "blame", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["blame", "core.md"])
+    assert result.exit_code != 0
+    assert "Error blaming" in result.output
+
+
+def test_history_error_exits_nonzero():
+    with patch.object(
+        git_mod.api_client, "get_history", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["history", "core.md"])
+    assert result.exit_code != 0
+    assert "Error showing history" in result.output
+
+
+def test_push_error_exits_nonzero():
+    with patch.object(
+        git_mod.api_client, "push", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["push"])
+    assert result.exit_code != 0
+    assert "Error pushing" in result.output
+
+
+def test_reindex_error_exits_nonzero():
+    with patch.object(
+        manage_mod.api_client, "reindex", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["reindex"])
+    assert result.exit_code != 0
+    assert "Error reindexing" in result.output
+
+
+def test_reindex_already_running_stays_zero():
+    """409 'already running' is informational, not a hard failure."""
+    with patch.object(
+        manage_mod.api_client, "reindex", side_effect=_http_status_error(409)
+    ):
+        result = CliRunner().invoke(main, ["reindex"])
+    assert result.exit_code == 0
+    assert "already running" in result.output
+
+
+def test_ingest_unreachable_api_exits_nonzero():
+    with patch.object(
+        ingest_mod.api_client,
+        "ingest_url",
+        side_effect=RequestError("connection refused"),
+    ):
+        result = CliRunner().invoke(main, ["ingest", "--url", "https://example.com"])
+    assert result.exit_code != 0
+    assert "Cannot reach API" in result.output
+
+
+def test_prime_error_exits_nonzero():
+    with patch.object(
+        prime_mod.api_client, "context_prime", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["prime"])
+    assert result.exit_code != 0
+    assert "Error priming context" in result.output
+
+
+def test_entities_error_exits_nonzero():
+    with patch.object(
+        query_mod.api_client, "get_entities", side_effect=RuntimeError("boom")
+    ):
+        result = CliRunner().invoke(main, ["entities"])
+    assert result.exit_code != 0
+    assert "Error showing entities" in result.output
+
+
+def test_config_edit_missing_file_exits_nonzero(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PALINODE_CONFIG", raising=False)
+    monkeypatch.setattr(
+        "palinode.core.config.config.memory_dir",
+        str(tmp_path / "missing-memory"),
+    )
+    result = CliRunner().invoke(main, ["config", "edit"])
+    assert result.exit_code != 0
+    assert "Config file not found" in result.output


### PR DESCRIPTION
## Summary
- CLI red-error handlers that previously printed and returned (exit 0) now `raise SystemExit(1)`, matching the house idiom in `review.py`.
- Covered the handlers listed in #164 (return-paths and fall-offs).
- Left alone: yellow "reindex already running" (HTTP 409) — informational, not a hard failure.
- Added regression tests patterned on `tests/test_cli_stop.py`.

Fixes https://github.com/phasespace-labs/palinode/issues/164

## Test plan
- [x] `pytest tests/test_cli_error_exit_codes.py tests/test_cli_stop.py` (17 passed)
- [ ] Spot-check: force an API failure on `palinode depends --unblocked` / `palinode trace …` and confirm non-zero exit

Assisted-by: Cursor
