### PR TITLE
test(archive): decode and encode archive history as UTF-8, not the locale

### DIFF
--- a/tests/test_archive_on_demand_664.py
+++ b/tests/test_archive_on_demand_664.py
@@ -86,7 +86,7 @@ def _write_and_index(memory_dir: str, relpath: str, body: str, frontmatter: dict
     path = os.path.join(memory_dir, relpath)
     os.makedirs(os.path.dirname(path), exist_ok=True)
     fm = yaml.safe_dump(frontmatter, default_flow_style=False)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(f"---\n{fm}---\n\n{body}\n")
     index_file(path)
     return path
@@ -95,14 +95,19 @@ def _write_and_index(memory_dir: str, relpath: str, body: str, frontmatter: dict
 def _meta(path: str) -> dict[str, Any]:
     from palinode.core import parser
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         meta, _ = parser.parse_markdown(f.read())
     return meta
 
 
 def _git(memory_dir: str, *args: str) -> str:
     return subprocess.run(
-        ["git", "-C", memory_dir, *args], check=True, capture_output=True, text=True
+        ["git", "-C", memory_dir, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
     ).stdout
 
 
@@ -126,7 +131,7 @@ def test_archive_sets_status_and_writes_history_sibling(store_env):
     assert _meta(os.path.join(store_env, "insights/claim-verification.md"))["status"] == "archived"
 
     history = os.path.join(store_env, "insights/claim-verification-history.md")
-    text = open(history).read()
+    text = open(history, encoding="utf-8").read()
     # The executor's own history writer: archived frontmatter + a dated entry
     # tagged with the memory's id, so the sibling is byte-shaped like a
     # consolidation ARCHIVE and `palinode trace` reads it unchanged.
@@ -135,14 +140,30 @@ def test_archive_sets_status_and_writes_history_sibling(store_env):
     assert "<!-- fact:insights-claim-verification -->" in text
 
 
+def test_archive_history_round_trips_non_ascii(store_env):
+    # The reason reaches the history sibling through the executor's writer, so
+    # a locale-default read here decodes it as cp1252 on native Windows and the
+    # assertion fails on content Palinode wrote as UTF-8.
+    reason = "retired after the caf\u00e9 rollout \u2014 \u65e5\u672c\u8a9e"
+    _write_and_index(
+        store_env, "insights/unicode-reason.md", "body",
+        {"id": "insights-unicode-reason", "category": "insights"},
+    )
+
+    archive_mod.archive_memory("insights/unicode-reason.md", reason=reason)
+
+    history = os.path.join(store_env, "insights/unicode-reason-history.md")
+    assert reason in open(history, encoding="utf-8").read()
+
+
 def test_archive_preserves_the_body(store_env):
-    marker = "the original body text must survive retirement"
+    marker = "the original body text must survive retirement \u2014 caf\u00e9, \u65e5\u672c\u8a9e"
     path = _write_and_index(
         store_env, "insights/keeper.md", marker,
         {"id": "insights-keeper", "category": "insights"},
     )
     archive_mod.archive_memory("insights/keeper.md")
-    assert marker in open(path).read()
+    assert marker in open(path, encoding="utf-8").read()
 
 
 def test_archived_memory_leaves_default_recall_but_is_retained(store_env):
@@ -213,7 +234,7 @@ def test_supersede_records_the_successor(store_env):
     assert meta["status"] == "archived"
     assert meta["superseded_by"] == "decisions/new-policy.md"
 
-    history = open(os.path.join(store_env, "decisions/old-policy-history.md")).read()
+    history = open(os.path.join(store_env, "decisions/old-policy-history.md"), encoding="utf-8").read()
     assert "Superseded by decisions/new-policy.md" in history
     assert "replaced after the re-promote" in history
     assert "supersede: decisions/old-policy.md -> decisions/new-policy.md" in _git(
@@ -278,7 +299,7 @@ def test_archive_is_idempotent_across_two_calls(store_env):
     second = archive_mod.archive_memory("insights/twice.md", reason="two")
     assert first["status"] == "archived"
     assert second["status"] == "already_archived"
-    history = open(os.path.join(store_env, "insights/twice-history.md")).read()
+    history = open(os.path.join(store_env, "insights/twice-history.md"), encoding="utf-8").read()
     assert history.count("reason: one") == 1
     assert "reason: two" not in history
 
@@ -304,14 +325,14 @@ def test_traversal_and_null_bytes_are_rejected(store_env, bad):
 
 def test_symlink_pointing_outside_memory_dir_is_rejected(store_env, tmp_path_factory):
     outside = tmp_path_factory.mktemp("outside") / "secret.md"
-    outside.write_text("---\nid: secret\n---\n\nnot yours\n")
+    outside.write_text("---\nid: secret\n---\n\nnot yours\n", encoding="utf-8")
     link = os.path.join(store_env, "insights", "escape.md")
     os.symlink(str(outside), link)
 
     with pytest.raises(ValueError):
         archive_mod.archive_memory("insights/escape.md")
     # The symlink target is untouched.
-    assert "status: archived" not in outside.read_text()
+    assert "status: archived" not in outside.read_text(encoding="utf-8")
 
 
 def test_superseded_by_is_held_to_the_same_path_guard(store_env):

--- a/tests/test_archive_recall_485.py
+++ b/tests/test_archive_recall_485.py
@@ -78,7 +78,7 @@ def memory_file(tmp_path, monkeypatch):
 
     monkeypatch.setattr(config, "memory_dir", str(tmp_path))
     path = os.path.join(str(tmp_path), "foo-status.md")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(
             "---\nid: foo\ncategory: project\n---\n\n"
             "# Foo\n\n"
@@ -92,7 +92,7 @@ def test_archive_history_file_is_status_archived(memory_file):
     apply_operations(memory_file, [{"op": "ARCHIVE", "id": "f2", "reason": "wrong"}])
     history_file = memory_file.replace("-status.md", "-history.md")
     assert os.path.exists(history_file)
-    hist = open(history_file).read()
+    hist = open(history_file, encoding="utf-8").read()
     assert "status: archived" in hist
     assert "An obsolete claim that is wrong" in hist
 
@@ -104,7 +104,7 @@ def test_supersede_history_file_is_status_archived(memory_file):
     )
     history_file = memory_file.replace("-status.md", "-history.md")
     assert os.path.exists(history_file)
-    assert "status: archived" in open(history_file).read()
+    assert "status: archived" in open(history_file, encoding="utf-8").read()
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +135,7 @@ def test_archived_fact_excluded_from_default_recall_but_retrievable(isolated_sto
 
     obsolete = "An obsolete claim that is wrong"
     src = os.path.join(isolated_store, "projects", "foo-status.md")
-    with open(src, "w") as f:
+    with open(src, "w", encoding="utf-8") as f:
         f.write(
             "---\nid: foo\ncategory: project\n---\n\n"
             "# Foo\n\n"

--- a/tests/test_ttl_archive_482.py
+++ b/tests/test_ttl_archive_482.py
@@ -133,7 +133,7 @@ def _write_and_index(memory_dir: str, relpath: str, body: str, frontmatter: dict
     path = os.path.join(memory_dir, relpath)
     os.makedirs(os.path.dirname(path), exist_ok=True)
     fm = yaml.safe_dump(frontmatter, default_flow_style=False)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(f"---\n{fm}---\n\n{body}\n")
     index_file(path)
     return path
@@ -178,7 +178,7 @@ def test_archive_expired_suppresses_from_recall_but_retains(isolated_store):
 
     # File frontmatter is now archived.
     from palinode.core import parser
-    with open(os.path.join(isolated_store, "inbox/probe-incident.md")) as f:
+    with open(os.path.join(isolated_store, "inbox/probe-incident.md"), encoding="utf-8") as f:
         meta, _ = parser.parse_markdown(f.read())
     assert meta["status"] == "archived"
 
@@ -226,7 +226,7 @@ def test_archive_expired_dry_run_writes_nothing(isolated_store):
     )
     result = ttl.archive_expired(dry_run=True)
     assert result["count"] == 1 and result["dry_run"] is True
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         meta, _ = parser.parse_markdown(f.read())
     assert meta.get("status") != "archived"  # untouched
 
@@ -264,7 +264,7 @@ def test_save_resolves_ttl_to_expires_at(api_client):
         "metadata": {"kind": "telemetry", "ttl": "1h"},
     })
     assert resp.status_code == 200, resp.text
-    with open(os.path.join(memory_dir, "inbox", "ttl-probe.md")) as f:
+    with open(os.path.join(memory_dir, "inbox", "ttl-probe.md"), encoding="utf-8") as f:
         meta, _ = parser.parse_markdown(f.read())
     assert "expires_at" in meta and "ttl" not in meta
     # roughly now + 1h
@@ -307,6 +307,6 @@ def test_archive_expired_endpoint(api_client):
     live = client.post("/archive-expired", json={"dry_run": False}).json()
     assert live["count"] == 1
     from palinode.core import parser
-    with open(os.path.join(memory_dir, "inbox", "endpoint-expired.md")) as f:
+    with open(os.path.join(memory_dir, "inbox", "endpoint-expired.md"), encoding="utf-8") as f:
         meta, _ = parser.parse_markdown(f.read())
     assert meta["status"] == "archived"

--- a/tests/test_utf8_encoding_guard.py
+++ b/tests/test_utf8_encoding_guard.py
@@ -69,6 +69,9 @@ _SWEPT_TEST_FILES: tuple[str, ...] = (
     "tests/test_session_end_status_line.py",
     "tests/test_session_end_timeout.py",
     "tests/integration/test_session_end_e2e_l1_l3.py",
+    "tests/test_archive_on_demand_664.py",
+    "tests/test_archive_recall_485.py",
+    "tests/test_ttl_archive_482.py",
 )
 
 _TEXT_MODE_TEMPFILE = {"NamedTemporaryFile", "TemporaryFile", "SpooledTemporaryFile"}


### PR DESCRIPTION
Part of #93, the fourth and last of the four areas we agreed: `/save` output paths (#152), daily and status files (#153), executor outputs (#149), and archive history here.

### Change

18 sites across `test_archive_on_demand_664.py`, `test_archive_recall_485.py` and `test_ttl_archive_482.py` now name `encoding="utf-8"`. Seventeen are `open` / `read_text` / `write_text` on files Palinode itself wrote; the eighteenth is the `_git` helper's `subprocess.run`, which had `text=True` with no encoding and was caught by the guard rather than by me.

All three files join `_SWEPT_TEST_FILES`, so the area cannot regress.

### Why the fixtures changed too

Every assertion in these files was ASCII, so they passed with or without the fix and would have been a regression guard rather than a reproduction. Two now carry non-ASCII, matching what #153 did:

- `test_archive_preserves_the_body` keeps `café, 日本語` in the body it asserts survives.
- `test_archive_history_round_trips_non_ascii` is new, and puts a non-ASCII reason through the executor's history writer so the sibling file is read back the way `palinode trace` reads it.

### Validation

```
LC_ALL=C LANG=C PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 pytest \
  tests/test_archive_on_demand_664.py tests/test_archive_recall_485.py \
  tests/test_ttl_archive_482.py tests/test_utf8_encoding_guard.py
```

74 passed under ASCII stdio and under the normal locale. Reverting just the two read sites makes both new fixtures fail with `UnicodeDecodeError`, so they pin the defect rather than guarding a fix.

Full suite: 3254 passed, 10 skipped, 5 xfailed. ruff clean.

### On closing #93

This finishes the four areas, but the issue's acceptance criteria ask for the suite to be exercised on native Windows, which I still cannot do. The ASCII-stdio harness stands in for cp1252 stdio and catches the decode mismatch, but it is not the same as a Windows run. Your call whether that closes #93 or whether it stays open for a real Windows pass.