### PR TITLE
fix: skip directory fsync for Windows moves

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- Memory-file moves no longer fail on native Windows when directory fsync is
+  unavailable; they now use the same guarded durability fallback as atomic
+  writes.
 - CLI commands that printed a red error and then returned now exit non-zero
   (`raise SystemExit(1)`), so automation can detect failure. Left alone: the
   yellow "reindex already running" (HTTP 409) path, which is informational.

--- a/palinode/core/git_tools.py
+++ b/palinode/core/git_tools.py
@@ -223,10 +223,11 @@ def move_memory_file(src_path: str, dst_path: str) -> None:
     The move counterpart to :func:`write_memory_file`: both endpoints cross
     the same traversal guard, then the rename happens via ``os.replace``
     (atomic on a single filesystem, which every path under ``memory_dir``
-    is) and the destination directory is fsynced so the rename survives a
-    crash. Does not create the destination directory — callers that need one
-    create it first, same as :func:`write_memory_file` never creates
-    ``os.path.dirname(file_path)``.
+    is). Where the platform supports it, the destination directory is fsynced
+    so the rename survives a crash; Windows cannot open a directory for fsync,
+    so its rename metadata has weaker crash durability. Does not create the
+    destination directory — callers that need one create it first, same as
+    :func:`write_memory_file` never creates ``os.path.dirname(file_path)``.
 
     This function only moves the file; it does not commit. A caller commits
     the result via ``commit_memory_files([src_path, dst_path], message)`` —
@@ -240,7 +241,10 @@ def move_memory_file(src_path: str, dst_path: str) -> None:
     _validate_write_target(dst_path)
     directory = os.path.dirname(dst_path) or "."
     os.replace(src_path, dst_path)
-    _fsync_directory(directory)
+    # Windows cannot open a directory for fsync, so the rename's metadata
+    # durability is weaker there after a crash.
+    if not _is_windows():
+        _fsync_directory(directory)
 
 
 @dataclass(frozen=True)

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -165,6 +165,24 @@ def test_write_memory_file_skips_directory_fsync_on_windows(tmp_path, monkeypatc
     fsync_directory.assert_not_called()
 
 
+def test_move_memory_file_skips_directory_fsync_on_windows(tmp_path, monkeypatch):
+    """Windows cannot open a directory as a file descriptor for fsync."""
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    source = tmp_path / "daily.md"
+    archive = tmp_path / "archive"
+    destination = archive / "daily.md"
+    source.write_text("daily note\n", encoding="utf-8")
+    archive.mkdir()
+    monkeypatch.setattr(git_tools, "_is_windows", lambda: True)
+
+    with patch.object(git_tools, "_fsync_directory") as fsync_directory:
+        git_tools.move_memory_file(str(source), str(destination))
+
+    assert not source.exists()
+    assert destination.read_text(encoding="utf-8") == "daily note\n"
+    fsync_directory.assert_not_called()
+
+
 def test_write_memory_file_overwrite_works_without_fchmod(tmp_path, monkeypatch):
     """Python 3.11/3.12 Windows needs the path-based chmod fallback."""
     # See the note in the sibling test above: the write target must live under


### PR DESCRIPTION
## Summary

- skip destination-directory fsync for memory-file moves on native Windows, matching the existing atomic-write fallback
- document the weaker crash-metadata durability on Windows
- add a regression test that verifies the file is moved without calling the unsupported directory fsync
- record the fix in the unreleased changelog

Fixes #168

## Testing

- pytest tests/test_git_tools.py -q (11 passed)
- related git-tools and consolidation tests (97 passed)
- ruff check palinode/ tests/ scripts/
- bandit -r palinode/ -ll
- git diff --check