### PR TITLE
fix(search): show similarity, not fused rank, as match

### DIFF
--- a/palinode/cli/search.py
+++ b/palinode/cli/search.py
@@ -4,6 +4,7 @@ from palinode.cli._api import HTTPStatusError, api_client
 from palinode.cli._format import print_result, console, OutputFormat, get_default_format
 from palinode.core.config import config
 from palinode.core.parity import CATEGORIES, MEMORY_TYPES
+from palinode.core.scoring import describe_match
 
 
 def _cli_resolve_context() -> list[str] | None:
@@ -125,7 +126,7 @@ def search(
                 return
             
             for res in results:
-                score_str = f"[{res['score']:.2f}] " if score else ""
+                score_str = f"[{describe_match(res)}] " if score else ""
                 title = res.get("file", "Untitled")
                 # prefer the API-provided snippet — already match-windowed
                 # and bounded. Fall back to the legacy blind-truncation path

--- a/palinode/core/scoring.py
+++ b/palinode/core/scoring.py
@@ -1,0 +1,35 @@
+"""How a search hit's score is described to a person.
+
+The fused score is a rank, not a similarity. RRF gives the top-ranked hit
+1.0 whether it is an excellent match or the least bad of a weak field, so no
+surface presents it as confidence. Cosine is presented that way, when the
+vector arm produced one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_RAW_SCORE = "raw_score"
+
+
+def describe_match(result: Mapping[str, Any]) -> str:
+    """A short phrase for how well ``result`` matched.
+
+    Three cases, and the middle one is the reason this exists:
+
+    - a cosine similarity is present, so say so as a percentage
+    - ``raw_score`` is present and ``None``: a BM25-only hit, which the
+      ranker marks explicitly. There is no similarity to report, so none is
+      claimed, and the fused value is shown labelled as rank
+    - ``raw_score`` is absent: a pre-0.12 server that never sent the field.
+      The arm is unknown, so the rank is all that can be said
+    """
+    fused = result.get("score") or 0.0
+    if _RAW_SCORE not in result:
+        return f"rank {fused:.2f}"
+    raw = result.get(_RAW_SCORE)
+    if raw is None:
+        return f"keyword match, rank {fused:.2f}"
+    return f"{round(raw * 100)}% match"

--- a/palinode/mcp.py
+++ b/palinode/mcp.py
@@ -53,6 +53,7 @@ from palinode.core.defaults import (
     _SESSION_END_TIMEOUT_SENTINEL as _SENTINEL,
 )
 from palinode.core.parity import CATEGORIES, MEMORY_TYPES, PROMPT_TASKS
+from palinode.core.scoring import describe_match
 from palinode.core.path_guard import to_rel_path
 from palinode.core.typed_links import parse_link_refs
 from palinode.core.write_input import (
@@ -638,7 +639,7 @@ def _format_results(results: list[dict[str, Any]], full: bool = False) -> str:
     any_truncated = False
     for r in results:
         rel = _rel_path_from(r)
-        score_pct = int(r.get("score", 0) * 100)
+        match_label = describe_match(r)
         freshness = r.get("freshness")
         fresh_label = f" ✓ {freshness}" if freshness == "valid" else (f" ⚠ {freshness}" if freshness == "stale" else "")
         # Render external_refs when present in result metadata.
@@ -710,7 +711,7 @@ def _format_results(results: list[dict[str, Any]], full: bool = False) -> str:
                 any_truncated = True
 
         parts.append(
-            f"[{rel}] ({score_pct}% match){fresh_label}{epi_label}{links_label}{refs_label}\n{(body or '').strip()}"
+            f"[{rel}] ({match_label}){fresh_label}{epi_label}{links_label}{refs_label}\n{(body or '').strip()}"
         )
 
     rendered = "\n\n---\n\n".join(parts)

--- a/tests/test_search_score_presentation.py
+++ b/tests/test_search_score_presentation.py
@@ -1,0 +1,62 @@
+"""A fused rank is never presented as match confidence."""
+
+import pytest
+from click.testing import CliRunner
+from unittest.mock import patch
+
+from palinode.core.scoring import describe_match
+from palinode.mcp import _format_results
+from palinode.cli.search import search
+
+
+# The measured case from the issue: 32 searches whose answer was absent from
+# the corpus all reported a fused 1.0, while cosine ranged 0.402 to 0.459.
+ABSENT_ANSWER_COSINE = 0.421
+
+
+def test_a_top_ranked_weak_match_is_not_reported_as_certain() -> None:
+    assert describe_match({"score": 1.0, "raw_score": ABSENT_ANSWER_COSINE}) == "42% match"
+
+
+def test_a_keyword_only_hit_claims_no_similarity() -> None:
+    # The ranker sets raw_score=None for BM25-only results. There is no cosine
+    # to report, so the fused value is shown as rank and nothing calls it a match.
+    described = describe_match({"score": 1.0, "raw_score": None})
+    assert described == "keyword match, rank 1.00"
+    assert "%" not in described
+
+
+def test_an_absent_raw_score_is_not_the_same_as_a_null_one() -> None:
+    # A pre-0.12 server never sent the field, so which arm hit is unknown.
+    assert describe_match({"score": 1.0}) == "rank 1.00"
+    assert describe_match({"score": 1.0, "raw_score": None}) != describe_match({"score": 1.0})
+
+
+@pytest.mark.parametrize("raw_score", [0.402, 0.421, 0.459])
+def test_the_whole_measured_range_renders_below_half(raw_score: float) -> None:
+    percent = int(describe_match({"score": 1.0, "raw_score": raw_score}).split("%")[0])
+    assert percent < 50
+
+
+def test_the_mcp_surface_stops_calling_a_fused_rank_a_match() -> None:
+    rendered = _format_results(
+        [{"file": "notes/a.md", "score": 1.0, "raw_score": ABSENT_ANSWER_COSINE, "snippet": "body"}]
+    )
+    assert "(42% match)" in rendered
+    assert "100% match" not in rendered
+
+
+def test_the_mcp_surface_claims_no_similarity_for_a_keyword_only_hit() -> None:
+    rendered = _format_results(
+        [{"file": "notes/a.md", "score": 1.0, "raw_score": None, "snippet": "body"}]
+    )
+    assert "(keyword match, rank 1.00)" in rendered
+    assert "% match" not in rendered
+
+
+def test_the_cli_score_flag_shows_similarity_not_rank() -> None:
+    hit = {"file": "notes/a.md", "score": 1.0, "raw_score": ABSENT_ANSWER_COSINE, "snippet": "body"}
+    with patch("palinode.cli.search.api_client.search", return_value=[hit]):
+        result = CliRunner().invoke(search, ["anything", "--score", "--format", "text"])
+    assert "[42% match]" in result.output
+    assert "[1.00]" not in result.output


### PR DESCRIPTION
Part of #150, taking the two Python surfaces. The OpenClaw and shared-core TypeScript renderers and the hook pair are not in this PR.

Presentation only, as you asked. `score` and `raw_score` on the REST payload are untouched.

The three cases are decided in one place, `palinode/core/scoring.py`, rather than once per surface. You flagged the duplicated jq as a wart you did not want extended; two Python renderers making the same judgement separately is the same wart in a different language, so MCP and the CLI now both call `describe_match`.

| Result | Before | After |
|---|---|---|
| cosine 0.421, fused 1.0 | `100% match` | `42% match` |
| `raw_score: null` (BM25-only) | `100% match` | `keyword match, rank 1.00` |
| `raw_score` absent (pre-0.12) | `100% match` | `rank 1.00` |

I kept the null and absent cases apart, as you asked. A null means the ranker told us this hit had no vector arm, so the surface says which arm did fire. An absent field means the server never sent one and the arm is unknown, so the rank is all it says. Neither claims a similarity.

On the naming: `rank`, used everywhere. For the BM25-only case I went with a word rather than silence. `keyword match` says what actually matched, and dropping the number entirely loses the ordering a reader is using the flag to see. It reads as a match without ever reading as a similarity, which was the property you wanted.

**Validation**

- `pytest -q`: 3263 passed, 10 skipped, 5 xfailed
- `ruff check`: clean
- The three surface tests fail on unfixed renderers and pass on the fix. Reverting just `mcp.py` and `search.py` gives `[1.00] notes/a.md` from the CLI and `(100% match)` from MCP.

The tests use the measured numbers from the issue: 0.421 as the median of the 32 searches, and each of the three points across the 0.402 to 0.459 range asserted to render under half.