### PR TITLE
fix(hook): claim no similarity when raw_score is null

### DIFF
--- a/examples/hooks/palinode-user-prompt-submit.sh
+++ b/examples/hooks/palinode-user-prompt-submit.sh
@@ -137,18 +137,27 @@ if [ "$MAX_RESULTS" -gt 0 ]; then
     # is a hard jq ERROR (not null), so `.results // .` dies on the real
     # response shape and fail-open turns the crash into permanent silence.
     LINES=$(echo "$HITS" | jq -r '
+      def fmt2: (. * 100 | round) as $c
+        | (($c / 100) | floor | tostring) + "." + ((($c % 100) + 100 | tostring)[1:]);
+      def describe:
+        if (has("raw_score") | not) then "rank " + ((.score // 0) | fmt2)
+        elif .raw_score == null then "keyword match, rank " + ((.score // 0) | fmt2)
+        else ((.raw_score * 100 | round | tostring) + "% match") end;
       (if type == "object" then (.results // []) else . end) as $r
       | if ($r | type) == "array" and ($r | length) > 0 then
           $r | map("- [" + (.rel_path // .file_path // "?") + "] ("
-                   + ((.raw_score // .score // 0) * 100 | floor | tostring) + "%) "
+                   + describe + ") "
                    + ((.snippet // .content // "") | gsub("\n"; " ")))
              | join("\n")
         else empty end' 2>/dev/null) || LINES=""
-  # raw_score, not score: `score` is the post-fusion RANK value — the top hit
-  # reads ~100% even for an irrelevant query — while `raw_score` is the cosine
-  # the THRESHOLD knob filters on. Showing the knob's own scale is what makes
-  # the lever tunable from what the user sees. (`.score` fallback: pre-0.12
-  # servers without raw_score.)
+  # `score` is the post-fusion RANK value: the top hit reads ~100% even for an
+  # irrelevant query. `raw_score` is the cosine the THRESHOLD knob filters on,
+  # so showing the knob's own scale is what makes the lever tunable from what
+  # the user sees. The two missing cases are not the same. A null raw_score is
+  # a BM25-only hit the ranker marked, and it has no similarity to report, so
+  # none is claimed. An absent raw_score is a pre-0.12 server, where the arm is
+  # unknown and the rank is all that can be said. Same three cases as
+  # describe_match in palinode/core/scoring.py.
     if [ -n "$LINES" ]; then
       SECTIONS="${SECTIONS}
 ### Related memories

--- a/palinode/cli/init.py
+++ b/palinode/cli/init.py
@@ -544,18 +544,27 @@ if [ "$MAX_RESULTS" -gt 0 ]; then
     # is a hard jq ERROR (not null), so `.results // .` dies on the real
     # response shape and fail-open turns the crash into permanent silence.
     LINES=$(echo "$HITS" | jq -r '
+      def fmt2: (. * 100 | round) as $c
+        | (($c / 100) | floor | tostring) + "." + ((($c % 100) + 100 | tostring)[1:]);
+      def describe:
+        if (has("raw_score") | not) then "rank " + ((.score // 0) | fmt2)
+        elif .raw_score == null then "keyword match, rank " + ((.score // 0) | fmt2)
+        else ((.raw_score * 100 | round | tostring) + "% match") end;
       (if type == "object" then (.results // []) else . end) as $r
       | if ($r | type) == "array" and ($r | length) > 0 then
           $r | map("- [" + (.rel_path // .file_path // "?") + "] ("
-                   + ((.raw_score // .score // 0) * 100 | floor | tostring) + "%) "
+                   + describe + ") "
                    + ((.snippet // .content // "") | gsub("\\n"; " ")))
              | join("\\n")
         else empty end' 2>/dev/null) || LINES=""
-  # raw_score, not score: `score` is the post-fusion RANK value — the top hit
-  # reads ~100% even for an irrelevant query — while `raw_score` is the cosine
-  # the THRESHOLD knob filters on. Showing the knob's own scale is what makes
-  # the lever tunable from what the user sees. (`.score` fallback: pre-0.12
-  # servers without raw_score.)
+  # `score` is the post-fusion RANK value: the top hit reads ~100% even for an
+  # irrelevant query. `raw_score` is the cosine the THRESHOLD knob filters on,
+  # so showing the knob's own scale is what makes the lever tunable from what
+  # the user sees. The two missing cases are not the same. A null raw_score is
+  # a BM25-only hit the ranker marked, and it has no similarity to report, so
+  # none is claimed. An absent raw_score is a pre-0.12 server, where the arm is
+  # unknown and the rank is all that can be said. Same three cases as
+  # describe_match in palinode/core/scoring.py.
     if [ -n "$LINES" ]; then
       SECTIONS="${SECTIONS}
 ### Related memories

--- a/tests/test_user_prompt_submit_hook.py
+++ b/tests/test_user_prompt_submit_hook.py
@@ -120,10 +120,61 @@ def test_search_hits_injected_as_snippets(tmp_path):
     assert proc.returncode == 0, proc.stderr
     ctx = _context_of(proc)
     assert "decisions/deploy-rollback.md" in ctx
-    assert "(62%)" in ctx, "should render raw_score, the knob's scale"
-    assert "(100%)" not in ctx, "must not render the fused rank score"
+    assert "(62% match)" in ctx, "should render raw_score, the knob's scale"
+    assert "(100% match)" not in ctx, "must not render the fused rank score"
     assert "git revert + reindex" in ctx
     assert "Related memories" in ctx
+
+
+def test_a_keyword_only_hit_claims_no_similarity(tmp_path):
+    """raw_score is present and null: a BM25-only hit the ranker marked.
+
+    There is no cosine to report, so the hook reports none. Falling back to
+    the fused value here is the original bug wearing a fallback.
+    """
+    hits = [{"rel_path": "notes/a.md", "score": 1.0, "raw_score": None,
+             "snippet": "body"}]
+    proc, _ = _run_hook(tmp_path, search_response=hits)
+    assert proc.returncode == 0, proc.stderr
+    ctx = _context_of(proc)
+    assert "(keyword match, rank 1.00)" in ctx
+    assert "%" not in ctx.split("### Related memories")[1]
+
+
+def test_an_absent_raw_score_is_not_the_same_as_a_null_one(tmp_path):
+    """A pre-0.12 server never sent the field, so which arm hit is unknown."""
+    absent = [{"rel_path": "notes/a.md", "score": 1.0, "snippet": "body"}]
+    null = [{"rel_path": "notes/a.md", "score": 1.0, "raw_score": None,
+             "snippet": "body"}]
+    a_dir, n_dir = tmp_path / "absent", tmp_path / "null"
+    a_dir.mkdir()
+    n_dir.mkdir()
+    absent_ctx = _context_of(_run_hook(a_dir, search_response=absent)[0])
+    null_ctx = _context_of(_run_hook(n_dir, search_response=null)[0])
+    assert "(rank 1.00)" in absent_ctx
+    assert absent_ctx != null_ctx
+
+
+def test_the_hook_renders_what_describe_match_would(tmp_path):
+    """The hook is a jq copy of palinode/core/scoring.py and must agree with it.
+
+    Same three cases, same wording. The Python surfaces and the hook drifting
+    apart is how one of them starts lying again.
+    """
+    from palinode.core.scoring import describe_match
+
+    cases = [
+        {"score": 1.0, "raw_score": 0.421},
+        {"score": 1.0, "raw_score": None},
+        {"score": 1.0},
+        {"score": 0.4},
+        {"score": 0.07},
+    ]
+    hits = [dict(c, rel_path=f"notes/{i}.md", snippet="body")
+            for i, c in enumerate(cases)]
+    ctx = _context_of(_run_hook(tmp_path, search_response=hits)[0])
+    for i, case in enumerate(cases):
+        assert f"[notes/{i}.md] ({describe_match(case)})" in ctx
 
 
 def test_envelope_response_shape_also_accepted(tmp_path):


### PR DESCRIPTION
The Claude Code hook and the copy `palinode init` writes out, the last two surfaces from #150.

`(.raw_score // .score // 0)` falls through on null, so a BM25-only hit rendered the fused rank as a percentage. `ranker.py:301` sets `raw_score=None` for those explicitly, so the top hit of any query, including an irrelevant one, rendered as a near-certain match.

The jq now runs the same three cases as `describe_match`:

| raw_score | before | after |
|---|---|---|
| 0.421 | `(42%)` | `(42% match)` |
| present, null | `(100%)` | `(keyword match, rank 1.00)` |
| absent | `(100%)` | `(rank 1.00)` |

Absent and null stay separate. A pre-0.12 server never sent the field, so the arm is unknown and the rank is all there is to say. A present null is a claim the ranker made and has no similarity behind it.

Both files carry the same jq, since `palinode init` writes the hook out and `test_embedded_copy_matches_canonical_example` holds them byte-identical.

Three tests, all failing on the unfixed hook. The last one renders five hits through the real script and asserts each line matches what `describe_match` returns for the same dict, so the jq and the Python cannot drift apart quietly.

Not touching `plugin/index.ts` or `plugins/core/src/index.ts`.