### PR TITLE
fix(plugins): label search scores accurately

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- The Pi/Cline shared plugin core and the OpenClaw plugin no longer present a fused rank as
+  similarity: vector hits show raw cosine as a match percentage, BM25-only hits show
+  `keyword match, rank N.NN`, and legacy responses without `raw_score` show `rank N.NN`
+  ([#175](https://github.com/phasespace-labs/palinode/issues/175)).
+
 ### Removed
 
 ### Security

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -304,6 +304,16 @@ async function palinodeFetch(
   return res.json();
 }
 
+/** Keep aligned with palinode/core/scoring.py; OpenClaw has not migrated to the shared core yet. */
+function describeMatch(result: { score?: number; raw_score?: number | null }): string {
+  const rank = (result.score ?? 0).toFixed(2);
+  if (result.raw_score === null) return `keyword match, rank ${rank}`;
+  if (typeof result.raw_score === "number") {
+    return `${Math.round(result.raw_score * 100)}% match`;
+  }
+  return `rank ${rank}`;
+}
+
 // ============================================================================
 // Plugin
 // ============================================================================
@@ -414,7 +424,7 @@ const palinodePlugin = {
             const text = results
               .map(
                 (r: any, i: number) =>
-                  `${i + 1}. [${r.category || "?"}] ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""} (score: ${(r.score * 100).toFixed(0)}%, file: ${path.basename(r.file_path)})`,
+                  `${i + 1}. [${r.category || "?"}] ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""} (${describeMatch(r)}, file: ${path.basename(r.file_path)})`,
               )
               .join("\n\n");
 

--- a/plugin/test/search-score-presentation.test.ts
+++ b/plugin/test/search-score-presentation.test.ts
@@ -1,0 +1,58 @@
+import * as path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import palinodePlugin from "../index";
+
+type Execute = (id: string, params: Record<string, unknown>) => Promise<any>;
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+function captureSearchExecute(): Execute {
+  let execute: Execute | undefined;
+  const api: any = {
+    pluginConfig: {
+      palinodeDir: path.join(process.cwd(), "test-memory"),
+      promptsDir: "specs/prompts",
+      autoRecall: false,
+      autoCapture: false,
+      midTurnMode: "none",
+    },
+    logger: { info: () => undefined, warn: () => undefined, error: () => undefined },
+    registerTool: (tool: { name: string; execute: Execute }) => {
+      if (tool.name === "palinode_search") execute = tool.execute;
+    },
+    on: () => undefined,
+    registerCli: () => undefined,
+    registerService: () => undefined,
+  };
+  palinodePlugin.register(api);
+  if (!execute) throw new Error("palinode_search was not registered");
+  return execute;
+}
+
+describe("palinode_search score presentation", () => {
+  it("distinguishes cosine, keyword-only, and legacy results", async () => {
+    global.fetch = async () =>
+      new Response(
+        JSON.stringify([
+          { category: "decisions", content: "vector", file_path: "/memory/vector.md", score: 1.0, raw_score: 0.421 },
+          { category: "insights", content: "keyword", file_path: "/memory/keyword.md", score: 1.0, raw_score: null },
+          { category: "research", content: "legacy", file_path: "/memory/legacy.md", score: 0.75 },
+        ]),
+        { status: 200 },
+      );
+
+    const result = await captureSearchExecute()("call-1", { query: "rollback" });
+    const text = result.content[0].text as string;
+
+    expect(text).toContain("[decisions] vector (42% match, file: vector.md)");
+    expect(text).toContain("[insights] keyword (keyword match, rank 1.00, file: keyword.md)");
+    expect(text).toContain("[research] legacy (rank 0.75, file: legacy.md)");
+    expect(text).not.toContain("score: 100%");
+    expect(text).not.toContain("score: 75%");
+  });
+});

--- a/plugins/cline/test/binding.test.ts
+++ b/plugins/cline/test/binding.test.ts
@@ -93,6 +93,27 @@ describe("beforeModel — the prompt-cache invariant", () => {
     expect(await p.hooks.beforeModel(request([user(PROMPT)]))).toBeUndefined();
   });
 
+  it("labels a BM25-only hit as rank rather than similarity", async () => {
+    const p = make({
+      ...QUIET,
+      "/search": {
+        results: [
+          {
+            rel_path: "notes/keyword.md",
+            score: 1.0,
+            raw_score: null,
+            snippet: "literal term",
+          },
+        ],
+      },
+    });
+    const result = await p.hooks.beforeModel(request([user(PROMPT)]));
+    const text = (result!.messages![1].content[0] as { text: string }).text;
+
+    expect(text).toContain("[notes/keyword.md] (keyword match, rank 1.00) literal term");
+    expect(text).not.toContain("(100%)");
+  });
+
   it("keeps the injected prefix byte-stable across iterations and later turns", async () => {
     const calls: Calls = [];
     const p = make(HIT, calls);

--- a/plugins/core/src/index.ts
+++ b/plugins/core/src/index.ts
@@ -178,9 +178,19 @@ interface SearchHit {
   /** Post-fusion rank value — ~1.0 for any query's top hit. Display fallback only. */
   score?: number;
   /** Raw cosine — the scale the threshold knob filters on. Preferred for display. */
-  raw_score?: number;
+  raw_score?: number | null;
   snippet?: string;
   content?: string;
+}
+
+/** Keep aligned with palinode/core/scoring.py; the packages remain independently deployable. */
+function describeMatch(result: SearchHit): string {
+  const rank = (result.score ?? 0).toFixed(2);
+  if (result.raw_score === null) return `keyword match, rank ${rank}`;
+  if (typeof result.raw_score === "number") {
+    return `${Math.round(result.raw_score * 100)}% match`;
+  }
+  return `rank ${rank}`;
 }
 
 interface FiredTrigger {
@@ -238,12 +248,8 @@ export async function buildRecallContext(
     const lines = results
       .map((r) => {
         const path = r.rel_path ?? r.file_path ?? "?";
-        // raw_score, not score: the fused rank value reads ~100% for the
-        // top hit of ANY query; raw cosine is the threshold knob's scale,
-        // so showing it makes the lever tunable from what the user sees.
-        const pct = Math.floor((r.raw_score ?? r.score ?? 0) * 100);
         const body = (r.snippet ?? r.content ?? "").replace(/\n/g, " ");
-        return `- [${path}] (${pct}%) ${body}`;
+        return `- [${path}] (${describeMatch(r)}) ${body}`;
       })
       .join("\n");
     return `\n### Related memories\n${lines}\n`;

--- a/plugins/core/test/core.test.ts
+++ b/plugins/core/test/core.test.ts
@@ -64,7 +64,7 @@ describe("the invariant the core owns", () => {
 });
 
 describe("buildRecallContext", () => {
-  it("renders search hits as bounded snippet lines", async () => {
+  it("describes cosine, keyword-only, and legacy search hits without treating rank as similarity", async () => {
     const fetchFn = stubFetch({
       "/check-triggers": [],
       "/search": {
@@ -73,12 +73,18 @@ describe("buildRecallContext", () => {
           // is the cosine the threshold knob filters on. Display must use
           // raw_score so the on-screen number matches the tunable scale.
           { rel_path: "decisions/deploy-rollback.md", score: 1.0, raw_score: 0.62, snippet: "git revert + reindex" },
+          { rel_path: "notes/keyword.md", score: 0.98, raw_score: null, snippet: "literal term" },
+          { rel_path: "notes/legacy.md", score: 0.75, snippet: "old server" },
         ],
       },
     });
     const ctx = await buildRecallContext(PROMPT, CFG, fetchFn);
-    expect(ctx).toContain("[decisions/deploy-rollback.md] (62%) git revert + reindex");
+    expect(ctx).toContain("[decisions/deploy-rollback.md] (62% match) git revert + reindex");
+    expect(ctx).toContain("[notes/keyword.md] (keyword match, rank 0.98) literal term");
+    expect(ctx).toContain("[notes/legacy.md] (rank 0.75) old server");
     expect(ctx).not.toContain("(100%)");
+    expect(ctx).not.toContain("(98%)");
+    expect(ctx).not.toContain("(75%)");
     expect(ctx).toContain("Related memories");
     expect(ctx).toContain("may be stale");
   });


### PR DESCRIPTION
## Summary

- render vector-hit similarity from raw_score in both TypeScript implementations
- distinguish explicit-null BM25 hits from legacy responses where raw_score is absent
- widen the shared wire type and add regression coverage for the shared core, Cline binding, and OpenClaw tool
- document the user-visible correction under Unreleased

The OpenClaw renderer and the Pi/Cline shared core remain separate in-place implementations, as requested. Their wording now follows the existing Python three-case contract.

## Validation

- Python: 3,392 passed, 10 skipped, 5 expected failures
- Ruff and Bandit
- HTTPX monopoly and write choke-point checks
- OpenClaw: 63 tests plus strict source type-check
- Shared core: 25 tests and build
- Cline: 17 tests and build
- Pi: 8 tests and build

Fixes #175

AI-assisted implementation; I reviewed the complete diff and validated it with the checks above.