### PR TITLE
fix(api): log skipped prompt files

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- `GET /prompts` now logs a warning naming any prompt file it cannot read while
+  continuing to return healthy prompts, making partial listings diagnosable
+  ([#179](https://github.com/phasespace-labs/palinode/issues/179)).
 - The Pi/Cline shared plugin core and the OpenClaw plugin no longer present a fused rank as
   similarity: vector hits show raw cosine as a match percentage, BM25-only hits show
   `keyword match, rank N.NN`, and legacy responses without `raw_score` show `rank N.NN`

--- a/palinode/api/routers/session.py
+++ b/palinode/api/routers/session.py
@@ -480,8 +480,8 @@ def list_prompts_api(
             if task and info["task"] != task:
                 continue
             results.append(info)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Skipping prompt file %s: %s", filepath, e)
 
     results.sort(key=lambda x: (x["task"], x["name"]))
     return results

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,12 +1,14 @@
 """Tests for the prompt versioning system (API endpoints + consolidation exclusion)."""
 from __future__ import annotations
 
+import logging
 import os
 
 import pytest
 import yaml
 from fastapi.testclient import TestClient
 
+from palinode.api.routers import session
 from palinode.api.server import app
 from palinode.core.config import config
 
@@ -68,6 +70,32 @@ def test_list_prompts_returns_all(mock_memory_dir):
     assert len(data) == 2
     names = {p["name"] for p in data}
     assert names == {"compaction-v1", "extraction-v1"}
+
+
+def test_list_prompts_logs_unreadable_file(mock_memory_dir, monkeypatch, caplog):
+    prompts_dir = os.path.join(mock_memory_dir, "prompts")
+    broken_path = _write_prompt(prompts_dir, "broken")
+    _write_prompt(prompts_dir, "healthy")
+    read_prompt_file = session._read_prompt_file
+
+    def read_with_one_failure(filepath):
+        if filepath == broken_path:
+            raise PermissionError("permission denied")
+        return read_prompt_file(filepath)
+
+    monkeypatch.setattr(session, "_read_prompt_file", read_with_one_failure)
+    with caplog.at_level(logging.WARNING, logger="palinode.api"):
+        resp = client.get("/prompts")
+
+    assert resp.status_code == 200
+    assert [prompt["name"] for prompt in resp.json()] == ["healthy"]
+    warnings = [
+        record for record in caplog.records
+        if record.name == "palinode.api" and record.levelno == logging.WARNING
+        and broken_path in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert "permission denied" in warnings[0].getMessage()
 
 
 def test_list_prompts_filter_by_task(mock_memory_dir):


### PR DESCRIPTION
## Summary

`GET /prompts` silently omitted files whose reads failed, making a partial listing indistinguishable from a directory that simply contained fewer prompts.

- Log a warning through the existing `palinode.api` logger with the affected path and exception, using lazy `%s` formatting.
- Continue returning healthy prompts; leave activation/deactivation behavior unchanged.
- Add a selective regression test using real prompt files, and an Unreleased changelog entry.

Closes https://github.com/phasespace-labs/palinode/issues/179

## Validation

- The new regression test fails before the fix because no warning is emitted, and passes afterward.
- `pytest tests/test_prompts.py -q --tb=short`: **16 passed**.
- `ruff check palinode/ tests/ scripts/`: passed.
- `bandit -r palinode/ -ll`: passed (no medium/high findings).
- `git diff --check`: passed.
- GitHub CI: all nine checks passed, including the unit-test jobs on Ubuntu (Python 3.11 and 3.12) and macOS (Python 3.12), plus both wheel smoke tests.

The broader local pytest run was interrupted after 637 passing tests when sandbox restrictions blocked loopback-server binds and existing subprocess tests attempted writes to the default home data directory. It was not a successful full-suite run; the CI unit-test jobs subsequently passed on all three configured platforms.
