### PR TITLE
fix(lint): narrow the staleness date-parse exception handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- `lint`'s two staleness checks no longer wrap their whole date-parse-and-compare
+  block in `except Exception: pass`. Only the `datetime.fromisoformat` call is
+  guarded now (against `ValueError`), and a non-date frontmatter value is handled
+  explicitly; any other error in the block propagates instead of silently dropping
+  the file from the staleness report
+  ([#180](https://github.com/phasespace-labs/palinode/issues/180)).
 - `GET /prompts` now logs a warning naming any prompt file it cannot read while
   continuing to return healthy prompts, making partial listings diagnosable
   ([#179](https://github.com/phasespace-labs/palinode/issues/179)).

--- a/palinode/core/lint.py
+++ b/palinode/core/lint.py
@@ -505,19 +505,22 @@ def run_lint_pass() -> dict[str, Any]:
         if meta.get("status") == "active":
             last_updated = meta.get("last_updated") or meta.get("created_at")
             if last_updated:
-                try:
-                    if isinstance(last_updated, str):
+                if isinstance(last_updated, str):
+                    try:
                         dt = datetime.fromisoformat(last_updated.replace('Z', '+00:00'))
-                    else:
-                        dt = last_updated
-                        if dt.tzinfo is None:
-                            dt = dt.replace(tzinfo=timezone.utc)
+                    except ValueError:
+                        dt = None  # malformed date string — skip this file
+                elif isinstance(last_updated, datetime):
+                    dt = last_updated
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                else:
+                    dt = None  # frontmatter held something that is not a date
 
+                if dt is not None:
                     days_old = (now - dt).days
                     if days_old > 90:
                         stale_files.append({"file": path, "days_old": days_old})
-                except Exception:
-                    pass
 
         # 6b. Stale open questions — an unresolved open_question that's
         # months old wants attention. Independent of `status` (an open question
@@ -526,18 +529,22 @@ def run_lint_pass() -> dict[str, Any]:
         if meta.get("epistemic") == "open_question":
             oq_updated = meta.get("last_updated") or meta.get("created_at")
             if oq_updated:
-                try:
-                    if isinstance(oq_updated, str):
+                if isinstance(oq_updated, str):
+                    try:
                         oq_dt = datetime.fromisoformat(oq_updated.replace('Z', '+00:00'))
-                    else:
-                        oq_dt = oq_updated
-                        if oq_dt.tzinfo is None:
-                            oq_dt = oq_dt.replace(tzinfo=timezone.utc)
+                    except ValueError:
+                        oq_dt = None  # malformed date string — skip this file
+                elif isinstance(oq_updated, datetime):
+                    oq_dt = oq_updated
+                    if oq_dt.tzinfo is None:
+                        oq_dt = oq_dt.replace(tzinfo=timezone.utc)
+                else:
+                    oq_dt = None  # frontmatter held something that is not a date
+
+                if oq_dt is not None:
                     oq_age = (now - oq_dt).days
                     if oq_age > 90:
                         stale_open_questions.append({"file": path, "days_old": oq_age})
-                except Exception:
-                    pass
 
         # 7. Wiki drift — frontmatter entities vs. body wikilinks.
         # Skipped for daily/ logs, the second outlier found in this pass: they

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -470,3 +470,101 @@ def test_lint_text_represents_every_lint_result_key(tmp_path, monkeypatch):
     assert set(data) == set(output_markers)
     for key, marker in output_markers.items():
         assert marker in output, f"{key} is absent from text output"
+
+
+# ---------------------------------------------------------------------------
+# Staleness date parsing
+# https://github.com/phasespace-labs/palinode/issues/180
+#
+# Both staleness blocks in run_lint_pass used to wrap the whole parse-and-check
+# in `except Exception: pass`. That skipped files with an unparseable date, as
+# intended, but it also swallowed genuine bugs in the block (an AttributeError
+# from a typo, say) and dropped the file from the report with no signal. The
+# guarded step is now only the `fromisoformat` parse: a bad date string or a
+# non-date value is skipped, anything else propagates.
+# ---------------------------------------------------------------------------
+
+_STALE_AGE_DAYS = 200
+
+
+def _write_dated(path, name, *, marker, last_updated, quote=False):
+    value = f'"{last_updated}"' if quote else last_updated
+    (path / name).write_text(
+        f"---\nid: people-{name[:-3]}\ncategory: people\ntype: Person\n"
+        f"{marker}\nlast_updated: {value}\n---\nBody",
+        encoding="utf-8",
+    )
+
+
+def _old_date():
+    return (datetime.now(timezone.utc) - timedelta(days=_STALE_AGE_DAYS)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+@pytest.mark.parametrize(
+    ("marker", "bucket"),
+    [
+        ("status: active", "stale_files"),
+        ("epistemic: open_question", "stale_open_questions"),
+    ],
+)
+def test_stale_check_reports_a_well_formed_old_date(tmp_path, monkeypatch, marker, bucket):
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    people = tmp_path / "people"
+    people.mkdir()
+    _write_dated(people, "old.md", marker=marker, last_updated=_old_date())
+
+    result = run_lint_pass()
+
+    assert any(entry["file"].endswith("old.md") for entry in result[bucket])
+
+
+@pytest.mark.parametrize(
+    ("marker", "bucket"),
+    [
+        ("status: active", "stale_files"),
+        ("epistemic: open_question", "stale_open_questions"),
+    ],
+)
+def test_stale_check_skips_unparseable_and_non_date_values(tmp_path, monkeypatch, marker, bucket):
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    people = tmp_path / "people"
+    people.mkdir()
+    _write_dated(people, "old.md", marker=marker, last_updated=_old_date())
+    _write_dated(people, "malformed.md", marker=marker, last_updated="not-a-date")
+    _write_dated(people, "numeric.md", marker=marker, last_updated="12345")
+
+    result = run_lint_pass()
+
+    flagged = [entry["file"] for entry in result[bucket]]
+    assert any(f.endswith("old.md") for f in flagged)
+    assert not any(f.endswith("malformed.md") for f in flagged)
+    assert not any(f.endswith("numeric.md") for f in flagged)
+
+
+@pytest.mark.parametrize(
+    ("marker", "bucket"),
+    [
+        ("status: active", "stale_files"),
+        ("epistemic: open_question", "stale_open_questions"),
+    ],
+)
+def test_stale_check_does_not_swallow_unexpected_errors(tmp_path, monkeypatch, marker, bucket):
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    people = tmp_path / "people"
+    people.mkdir()
+    # Quoted so the value stays a string and reaches the fromisoformat call.
+    _write_dated(people, "old.md", marker=marker, last_updated=_old_date(), quote=True)
+
+    import palinode.core.lint as lint_module
+
+    class _ExplodingDatetime(lint_module.datetime):
+        @classmethod
+        def fromisoformat(cls, value):
+            raise AttributeError("simulated bug in the staleness block")
+
+    monkeypatch.setattr(lint_module, "datetime", _ExplodingDatetime)
+
+    with pytest.raises(AttributeError):
+        run_lint_pass()


### PR DESCRIPTION
## What

Both staleness checks in `run_lint_pass` (`palinode/core/lint.py`) — the `status == active` check that feeds `stale_files`, and the `epistemic == open_question` check that feeds `stale_open_questions` — wrapped their whole parse-and-compare block in `except Exception: pass`.

## Why it's wrong

The intent is *"a date I cannot parse means skip this file"*, which is fine. But the bare `except` also catches an `AttributeError` from a typo, a `KeyError` from a renamed field, or any other genuine bug in the block, and turns it into a file quietly missing from the staleness report. `lint` then under-reports with no signal.

## What changed

Restructured both blocks so only the parse is guarded:

- `datetime.fromisoformat(...)` is wrapped in `except ValueError` — the one failure the code genuinely expects from a malformed string.
- A non-date frontmatter value (an int or list out of YAML) is handled by an explicit `else` branch instead of being discovered by an `AttributeError`.
- The age comparison runs only when a `datetime` was obtained.
- Anything else raised in the block now propagates.

No new imports (`datetime` / `timezone` already imported). The other two swallow sites in this file (lines ~429 and ~441) are deliberately left alone — different judgement, and out of scope here. Reporting the skipped files (an `unparseable_dates` bucket) would change the report schema and belongs in its own issue.

Behaviour for the cases the old code handled is unchanged: a malformed date string or a non-date value is still skipped and the pass still completes.

## Tests

`tests/test_lint.py`, parametrized over both checks:

- a well-formed old date is still reported (regression guard);
- a malformed string (`last_updated: not-a-date`) is skipped and the pass completes;
- a non-date value (`last_updated: 12345`) is skipped and the pass completes;
- an unexpected error inside the block (simulated `AttributeError` from `fromisoformat`) propagates rather than being swallowed — this one fails before the change and passes after.

`pytest tests/test_lint.py` green (93 passed). `ruff check palinode/ tests/ scripts/` and `bandit -r palinode/ -ll` clean. CHANGELOG entry added under `## Unreleased` → `### Fixed`.

Closes https://github.com/phasespace-labs/palinode/issues/180