### PR TITLE
fix(git_tools): batch history() into one git log walk

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- `git_tools.history()` now reports diff stats and, under `detail="full"`, diffs for commits
+  older than a rename, and for the repository's root commit. Both were computed by a
+  per-commit `git diff --stat` / `git show` that passed the file's current path without
+  `--follow`, so git was asked about a path that did not exist at those commits and returned
+  a misleading figure or nothing at all. A single `git log --follow --shortstat` walk now
+  produces them, which also drops the subprocess count from one or two per commit to one per
+  call ([#158](https://github.com/phasespace-labs/palinode/issues/158)).
 - The Pi/Cline shared plugin core and the OpenClaw plugin no longer present a fused rank as
   similarity: vector hits show raw cosine as a match percentage, BM25-only hits show
   `keyword match, rank N.NN`, and legacy responses without `raw_score` show `rank N.NN`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,11 +27,14 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 - `git_tools.history()` now reports diff stats and, under `detail="full"`, diffs for commits
   older than a rename, and for the repository's root commit. Both were computed by a
-  per-commit `git diff --stat` / `git show` that passed the file's current path without
-  `--follow`, so git was asked about a path that did not exist at those commits and returned
-  a misleading figure or nothing at all. A single `git log --follow --shortstat` walk now
-  produces them, which also drops the subprocess count from one or two per commit to one per
-  call ([#158](https://github.com/phasespace-labs/palinode/issues/158)).
+  per-commit `git diff --stat` / `git show`. For commits older than a rename those passed the
+  file's current path without `--follow`, so git was asked about a path that did not exist yet
+  and returned a misleading figure or nothing; the root commit was blank for a separate
+  reason, that `{sha}^..{sha}` has no parent to resolve. A single
+  `git log --follow --shortstat` walk now produces both, dropping the subprocess count for a
+  20-commit history from 21 (41 under `detail="full"`) to 1. The `diff` string under
+  `detail="full"` now starts at `diff --git` rather than at the `git show` commit header
+  ([#158](https://github.com/phasespace-labs/palinode/issues/158)).
 - The Pi/Cline shared plugin core and the OpenClaw plugin no longer present a fused rank as
   similarity: vector hits show raw cosine as a match percentage, BM25-only hits show
   `keyword match, rank N.NN`, and legacy responses without `raw_score` show `rank N.NN`

--- a/palinode/core/git_tools.py
+++ b/palinode/core/git_tools.py
@@ -589,9 +589,12 @@ def blame(file_path: str, search: str | None = None) -> str:
 
 # A ``git log --format=%h|%aI|%s`` header line. Anchored on the hash and the
 # ISO-8601 date so a patch line can never be mistaken for one; the message is
-# the remainder and may itself contain "|".
+# the remainder and may itself contain "|". The hash width spans what %h can
+# actually produce -- core.abbrev goes down to 4, and an unabbreviated SHA-256
+# is 64 -- because the old positional split accepted any width and narrowing
+# it here would silently return no history at all.
 _HISTORY_ENTRY_RE = re.compile(
-    r"^(?P<hash>[0-9a-f]{7,40})\|(?P<date>\d{4}-\d{2}-\d{2}T[^|]*)\|(?P<message>.*)$"
+    r"^(?P<hash>[0-9a-f]{4,64})\|(?P<date>\d{4}-\d{2}-\d{2}T[^|]*)\|(?P<message>.*)$"
 )
 
 # A ``--shortstat`` summary line, e.g. " 1 file changed, 2 insertions(+)".
@@ -630,7 +633,10 @@ def history(
     # per-commit ``show`` did. Both are computed by the same --follow walk, so
     # they hold across renames -- a pathspec passed to a separate ``diff``/
     # ``show`` names the current path, which did not exist before the rename.
-    args = ["log", f"-{limit}", "--format=%h|%aI|%s", "--shortstat"]
+    # --no-color for the same reason diff() passes it: git honours
+    # color.ui=always even down a pipe, and a painted "diff --git" line no
+    # longer matches the prefix the shortstat guard keys on.
+    args = ["log", "--no-color", f"-{limit}", "--format=%h|%aI|%s", "--shortstat"]
     if detail == "full":
         args += ["-p", "--unified=3"]
     args += ["--follow", "--", file_path]
@@ -716,8 +722,7 @@ def last_commit(file_path: str) -> dict[str, str] | None:
     The newest-end counterpart to :func:`first_commit`: "when did this file last
     change on disk", as recorded by git. Same return shape (``hash``, ``date``,
     ``author``, ``message``) and the same ``None`` for an absent file or a path
-    with no git history. Single ``git log`` call — unlike :func:`history`, which
-    also shells out for a per-commit ``--stat``.
+    with no git history. Single ``git log`` call, as :func:`history` now is.
     """
     file_path = _resolve_memory_path(file_path)
     if not os.path.exists(os.path.join(config.memory_dir, file_path)):

--- a/palinode/core/git_tools.py
+++ b/palinode/core/git_tools.py
@@ -587,6 +587,17 @@ def blame(file_path: str, search: str | None = None) -> str:
     return header + blame_output
 
 
+# A ``git log --format=%h|%aI|%s`` header line. Anchored on the hash and the
+# ISO-8601 date so a patch line can never be mistaken for one; the message is
+# the remainder and may itself contain "|".
+_HISTORY_ENTRY_RE = re.compile(
+    r"^(?P<hash>[0-9a-f]{7,40})\|(?P<date>\d{4}-\d{2}-\d{2}T[^|]*)\|(?P<message>.*)$"
+)
+
+# A ``--shortstat`` summary line, e.g. " 1 file changed, 2 insertions(+)".
+_SHORTSTAT_RE = re.compile(r"^\s+\d+ files? changed")
+
+
 def history(
     file_path: str,
     limit: int = 20,
@@ -614,36 +625,58 @@ def history(
     if not os.path.exists(os.path.join(config.memory_dir, file_path)):
         return []
 
-    # Get commits that touched this file (--follow tracks renames)
-    result = _run_git(
-        "log", f"-{limit}", "--format=%h|%aI|%s",
-        "--follow", "--", file_path
-    )
+    # One walk, not one spawn per commit: --shortstat yields the same summary
+    # line the per-commit ``diff --stat`` tail used to, and -p yields what the
+    # per-commit ``show`` did. Both are computed by the same --follow walk, so
+    # they hold across renames -- a pathspec passed to a separate ``diff``/
+    # ``show`` names the current path, which did not exist before the rename.
+    args = ["log", f"-{limit}", "--format=%h|%aI|%s", "--shortstat"]
+    if detail == "full":
+        args += ["-p", "--unified=3"]
+    args += ["--follow", "--", file_path]
+    result = _run_git(*args)
 
     if not result.stdout.strip():
         return []
 
-    commits = []
-    for entry in result.stdout.strip().split("\n"):
-        parts = entry.split("|", 2)
-        if len(parts) == 3:
-            hash_short, date, message = parts
-            # Get the diff stat for this specific commit
-            stat = _run_git("diff", "--stat", f"{hash_short}^..{hash_short}", "--", file_path)
-            stat_line = stat.stdout.strip().split("\n")[-1] if stat.stdout.strip() else ""
-            stats = stat_line.strip() if stat_line and "changed" in stat_line else ""
-            commit: dict[str, str] = {
-                "hash": hash_short,
-                "date": date,
-                "message": message,
-                "stats": stats,
+    commits: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    diff_lines: list[str] = []
+    in_diff = False
+
+    for line in result.stdout.split("\n"):
+        header = _HISTORY_ENTRY_RE.match(line)
+        if header:
+            if current is not None:
+                if detail == "full":
+                    current["diff"] = "\n".join(diff_lines).strip()
+                commits.append(current)
+            current = {
+                "hash": header.group("hash"),
+                "date": header.group("date"),
+                "message": header.group("message"),
+                "stats": "",
             }
-            if detail == "full":
-                diff_result = _run_git(
-                    "show", "--unified=3", f"{hash_short}", "--", file_path
-                )
-                commit["diff"] = diff_result.stdout.strip()
-            commits.append(commit)
+            diff_lines = []
+            in_diff = False
+            continue
+        if current is None:
+            continue
+        if line.startswith("diff --git "):
+            in_diff = True
+        # Only before the patch body: a file's own content can contain a line
+        # that reads like a shortstat, and under detail="full" that content is
+        # in this same stream.
+        elif not in_diff and _SHORTSTAT_RE.match(line):
+            current["stats"] = line.strip()
+            continue
+        if detail == "full":
+            diff_lines.append(line)
+
+    if current is not None:
+        if detail == "full":
+            current["diff"] = "\n".join(diff_lines).strip()
+        commits.append(current)
 
     return commits
 

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -39,13 +39,14 @@ def test_rollback_creates_new_commit():
 
 def test_history_returns_structured_data():
     with patch("palinode.core.git_tools._run_git") as mock_run:
-        # First call: git log
+        # One call now: the log carries its own --shortstat summary.
         log_res = MagicMock()
-        log_res.stdout = "abc1234|2026-04-10T12:00:00+00:00|palinode: update file\n"
-        # Second call: git diff --stat
-        stat_res = MagicMock()
-        stat_res.stdout = " some/file.md | 3 ++-\n 1 file changed, 2 insertions(+), 1 deletion(-)\n"
-        mock_run.side_effect = [log_res, stat_res]
+        log_res.stdout = (
+            "abc1234|2026-04-10T12:00:00+00:00|palinode: update file\n"
+            "\n"
+            " 1 file changed, 2 insertions(+), 1 deletion(-)\n"
+        )
+        mock_run.return_value = log_res
 
         with patch("os.path.exists", return_value=True):
             result = git_tools.history("some/file.md", limit=10)

--- a/tests/test_git_tools_history.py
+++ b/tests/test_git_tools_history.py
@@ -1,0 +1,145 @@
+"""``git_tools.history`` must report stats and diffs across a rename.
+
+``history`` documents that it "uses ``--follow`` to track renames", and the
+``log`` call honours that. The per-commit ``diff --stat`` and ``show`` that
+used to fill in ``stats`` and ``diff`` did not: each passed the file's
+*current* path with no ``--follow``, so for any commit older than a rename
+git was asked about a path that did not exist yet. Three of the four commits
+below were wrong or blank.
+
+The repository's root commit was blank for a second, unrelated reason:
+``{sha}^..{sha}`` has no parent to compare against.
+
+Real git repositories throughout. A mocked ``_run_git`` returns whatever it
+was handed and cannot see either defect, which is why the mocked test stayed
+green while the behaviour was wrong.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from palinode.core import git_tools
+from palinode.core.config import config
+
+
+def _git(repo: str, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return result.stdout
+
+
+@pytest.fixture()
+def renamed_store(tmp_path, monkeypatch) -> str:
+    """A memory dir whose only file was committed, edited, renamed, edited."""
+    repo = str(tmp_path)
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    monkeypatch.setattr(config, "memory_dir", repo)
+
+    before = os.path.join(repo, "before.md")
+    with open(before, "w", encoding="utf-8") as handle:
+        handle.write("root line\n")
+    _git(repo, "add", "before.md")
+    _git(repo, "commit", "-qm", "add before.md")
+
+    with open(before, "w", encoding="utf-8") as handle:
+        handle.write("root line\npre-rename line\n")
+    _git(repo, "commit", "-qam", "edit before the rename")
+
+    _git(repo, "mv", "before.md", "after.md")
+    _git(repo, "commit", "-qm", "rename to after.md")
+
+    after = os.path.join(repo, "after.md")
+    with open(after, "w", encoding="utf-8") as handle:
+        handle.write("root line\npre-rename line\npost-rename line\n")
+    _git(repo, "commit", "-qam", "edit after the rename")
+    return repo
+
+
+def test_history_reports_stats_for_commits_older_than_the_rename(renamed_store):
+    commits = git_tools.history("after.md")
+
+    assert [entry["message"] for entry in commits] == [
+        "edit after the rename",
+        "rename to after.md",
+        "edit before the rename",
+        "add before.md",
+    ]
+    # Newest-first, so index 2 is the edit made while the file was still
+    # before.md. It was blank before: `diff --stat <sha>^..<sha> -- after.md`
+    # names a path that did not exist at that commit.
+    assert "changed" in commits[2]["stats"]
+
+
+def test_history_reports_stats_for_the_root_commit(renamed_store):
+    commits = git_tools.history("after.md")
+
+    # The repository's first commit has no parent, so `{sha}^..{sha}` used to
+    # fail outright and leave this blank whether or not a rename was involved.
+    assert "changed" in commits[3]["stats"]
+
+
+def test_history_full_detail_carries_the_pre_rename_change(renamed_store):
+    commits = git_tools.history("after.md", detail="full")
+
+    diff = commits[2]["diff"]
+    # Assert on a hunk, not on emptiness: `git show <sha> -- after.md` still
+    # printed the commit header for a path that did not exist yet, so the old
+    # code produced a non-empty diff with nothing in it. A non-emptiness check
+    # passes today and pins nothing.
+    assert "@@" in diff
+    assert "+pre-rename line" in diff
+
+
+def test_history_issues_one_git_call_per_request(renamed_store, monkeypatch):
+    """One walk, not one spawn per commit."""
+    calls: list[tuple[str, ...]] = []
+    real_run_git = git_tools._run_git
+
+    def recording_run_git(*args: str, **kwargs):
+        calls.append(args)
+        return real_run_git(*args, **kwargs)
+
+    monkeypatch.setattr(git_tools, "_run_git", recording_run_git)
+
+    assert len(git_tools.history("after.md", detail="full")) == 4
+    assert len(calls) == 1
+    assert calls[0][0] == "log"
+
+
+def test_history_does_not_read_file_content_as_a_stat_line(tmp_path, monkeypatch):
+    """A memory file may contain a line that reads exactly like a shortstat.
+
+    Under ``detail="full"`` that content travels in the same stream as the real
+    summary. It has to reach the parser as an unchanged *context* line to be
+    ambiguous at all -- an added line carries a "+" and cannot match -- so the
+    lookalike is committed first and something else is changed on top of it.
+    """
+    repo = str(tmp_path)
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    monkeypatch.setattr(config, "memory_dir", repo)
+
+    lookalike = " 99 files changed, 99 insertions(+)\n"
+    note = os.path.join(repo, "note.md")
+    with open(note, "w", encoding="utf-8") as handle:
+        handle.write("quoting git output:\n" + lookalike)
+    _git(repo, "add", "note.md")
+    _git(repo, "commit", "-qm", "add note.md")
+
+    with open(note, "w", encoding="utf-8") as handle:
+        handle.write("quoting git output:\n" + lookalike + "and one more line\n")
+    _git(repo, "commit", "-qam", "append a line below the lookalike")
+
+    commits = git_tools.history("note.md", detail="full")
+
+    # The lookalike is context in this commit's patch, so it is offered to the
+    # parser exactly as a shortstat line would be.
+    assert lookalike.rstrip("\n") in commits[0]["diff"]
+    assert commits[0]["stats"] == "1 file changed, 1 insertion(+)"

--- a/tests/test_git_tools_history.py
+++ b/tests/test_git_tools_history.py
@@ -143,3 +143,71 @@ def test_history_does_not_read_file_content_as_a_stat_line(tmp_path, monkeypatch
     # parser exactly as a shortstat line would be.
     assert lookalike.rstrip("\n") in commits[0]["diff"]
     assert commits[0]["stats"] == "1 file changed, 1 insertion(+)"
+
+
+def test_history_survives_color_ui_always(tmp_path, monkeypatch):
+    """``color.ui=always`` paints "diff --git", which the stat guard keys on.
+
+    git honours that setting down a pipe, so without ``--no-color`` the guard
+    never latches, and the stat-lookalike context line then overwrites the real
+    summary. Both conditions are needed: the paint alone corrupts nothing.
+    """
+    repo = str(tmp_path)
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "config", "color.ui", "always")
+    monkeypatch.setattr(config, "memory_dir", repo)
+
+    lookalike = " 99 files changed, 99 insertions(+)\n"
+    note = os.path.join(repo, "note.md")
+    with open(note, "w", encoding="utf-8") as handle:
+        handle.write("quoting git output:\n" + lookalike)
+    _git(repo, "add", "note.md")
+    _git(repo, "commit", "-qm", "add note.md")
+
+    with open(note, "w", encoding="utf-8") as handle:
+        handle.write("quoting git output:\n" + lookalike + "and one more line\n")
+    _git(repo, "commit", "-qam", "append a line below the lookalike")
+
+    commits = git_tools.history("note.md", detail="full")
+
+    assert commits[0]["stats"] == "1 file changed, 1 insertion(+)"
+
+
+def test_history_reads_a_short_abbreviated_hash(renamed_store):
+    """``core.abbrev`` goes down to 4, and ``%h`` honours it."""
+    _git(renamed_store, "config", "core.abbrev", "4")
+
+    commits = git_tools.history("after.md")
+
+    assert len(commits) == 4
+    assert "changed" in commits[0]["stats"]
+
+
+def test_history_keeps_a_pipe_in_the_commit_message(tmp_path, monkeypatch):
+    """``%s`` is the last field, so a message may contain the delimiter."""
+    repo = str(tmp_path)
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    monkeypatch.setattr(config, "memory_dir", repo)
+
+    note = os.path.join(repo, "piped.md")
+    with open(note, "w", encoding="utf-8") as handle:
+        handle.write("body\n")
+    _git(repo, "add", "piped.md")
+    _git(repo, "commit", "-qm", "save: a | b")
+
+    commits = git_tools.history("piped.md")
+
+    assert [entry["message"] for entry in commits] == ["save: a | b"]
+
+
+def test_history_honours_the_limit(renamed_store):
+    commits = git_tools.history("after.md", limit=2)
+
+    assert [entry["message"] for entry in commits] == [
+        "edit after the rename",
+        "rename to after.md",
+    ]


### PR DESCRIPTION
Closes #158.

`history()` ran `git log --follow` once, then a `git diff --stat` per commit and, at `detail="full"`, a `git show` per commit. That is 21 or 41 subprocesses for a 20-commit history. It is now one `git log --follow --shortstat` walk, with `-p` added for the full detail.

The stats and diffs change for some commits, which is the part worth reading.

The per-commit `diff --stat` and `show` passed the file's current path with no `--follow`, so for any commit older than a rename git was asked about a path that did not exist yet. On a four-commit repo where `before.md` became `after.md`:

| commit | before | after |
|---|---|---|
| edit after the rename | `1 file changed, 1 insertion(+)` | same |
| the rename | `1 file changed, 2 insertions(+)` | `1 file changed, 0 insertions(+), 0 deletions(-)` |
| edit before the rename | empty | `1 file changed, 1 insertion(+)` |
| the root commit | empty | `1 file changed, 1 insertion(+)` |

The root commit was blank for a separate reason: `{sha}^..{sha}` has no parent to compare against.

The docstring already said the function "uses `--follow` to track renames". The `log` call honoured that and the per-commit calls did not, so this brings the behaviour to what was documented rather than changing a chosen one.

## Tests

`tests/test_git_tools_history.py` is new and runs against real repositories, because a mocked `_run_git` returns whatever it was handed and cannot see any of this. Each test fails on the unfixed code:

- a pre-rename commit has non-empty stats (was blank)
- the root commit has non-empty stats (was blank)
- the pre-rename diff under `detail="full"` contains a hunk and the added line (was empty)
- one git call per request (was 9 on a four-commit history)

The diff assertion checks for `@@` and the added line rather than non-emptiness. `git show <sha> -- <new path>` still prints a commit header for a path that did not exist, so an emptiness check can pass on the old code and pin nothing.

A fifth test covers the parser rather than the bug: a memory file whose own content contains a line reading like a shortstat. It has to reach the parser as an unchanged context line to be ambiguous at all, since an added line carries a `+` and cannot match. It fails if the guard that stops stat-matching once the patch body starts is removed.

`test_history_returns_structured_data` moves to a single mocked response carrying the `--shortstat` output. Its return-shape assertions are unchanged; only the baked-in call count went.

## Parser hardening

Two things the batching introduced, both found by reviewing the parser against real git configs rather than the happy path, and both pinned by a test that fails without the fix:

- `--no-color` on the log call. git honours `color.ui=always` down a pipe, and a painted `diff --git` line does not match the prefix the stat guard keys on. Without it the guard never latches and the lookalike context line above overwrites the real summary, giving `stats` of `99 files changed, 99 insertions(+)` with an escape sequence still in it. `diff()` in the same module already passes `--no-color` for this reason.
- The header regex accepts a 4 to 64 character hash. `%h` honours `core.abbrev`, whose minimum is 4, and the old positional `split("|", 2)` accepted any width. At `core.abbrev=6` every header failed to match and `history()` returned `[]` for a file with commits, which surfaces as `200 {"history": []}` on the API and "No history found." over MCP.

Also covered now: `limit` below the number of available commits, and a commit message containing `|`.

One docstring correction rides along: `last_commit()` said `history` "shells out for a per-commit `--stat`", which this change makes false.

Full suite: 3401 passed, 10 skipped, 5 xfailed. `ruff check` clean.