### PR TITLE
perf(indexer): batch section embeddings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,11 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Changed
 
+- File reconciliation now sends every section awaiting an embedding in one ordered
+  Ollama `/api/embed` batch, validates the complete response before writing, and
+  preserves per-input FTS-only degradation and whole-file outage rollback
+  ([#159](https://github.com/phasespace-labs/palinode/issues/159)).
+
 ### Fixed
 
 - `lint`'s two staleness checks no longer wrap their whole date-parse-and-compare

--- a/palinode/core/embedder.py
+++ b/palinode/core/embedder.py
@@ -29,6 +29,7 @@ __all__ = [
     "EmbeddingInputError",
     "EmbeddingUnavailable",
     "embed",
+    "embed_many",
     "check_model_context",
 ]
 
@@ -216,6 +217,17 @@ def embed(text: str) -> list[float]:
     return _embed_local(text)
 
 
+def embed_many(texts: list[str]) -> list[list[float]]:
+    """Generate one ordered embedding per input in a single backend call.
+
+    The whole result is validated by :class:`OllamaClient` before it is
+    returned. Typed context and per-input failures propagate unchanged;
+    backend failures become :class:`EmbeddingUnavailable`, matching
+    :func:`embed`.
+    """
+    return _embed_many_local(texts)
+
+
 def _run_preflight_once() -> None:
     """Run the context preflight check exactly once per process."""
     global _preflight_done
@@ -284,4 +296,30 @@ def _embed_local(text: str) -> list[float]:
         _notice_keyword_only_once()
         raise EmbeddingUnavailable(
             backend="local", model=model, text_len=len(text), cause=str(e)
+        ) from e
+
+
+def _embed_many_local(texts: list[str]) -> list[list[float]]:
+    """Embed ``texts`` through the local provider's ordered batch boundary."""
+    if not texts:
+        return []
+
+    _run_preflight_once()
+    model = config.embeddings.primary.model
+    text_len = sum(len(text) for text in texts)
+    try:
+        return get_ollama_client().embed_many(texts)
+    except EmbeddingContextError:
+        raise
+    except EmbeddingInputError:
+        raise
+    except OllamaError as e:
+        logger.warning(
+            "batch embed failed; raising EmbeddingUnavailable "
+            "op=embed_many model=%s inputs=%d text_len=%d outcome=error error=%r",
+            model, len(texts), text_len, str(e),
+        )
+        _notice_keyword_only_once()
+        raise EmbeddingUnavailable(
+            backend="local", model=model, text_len=text_len, cause=str(e)
         ) from e

--- a/palinode/core/ollama_client.py
+++ b/palinode/core/ollama_client.py
@@ -220,6 +220,45 @@ def _extract_embedding_vector(data: Any) -> list[float] | None:
     return None
 
 
+def _extract_embedding_batch(
+    data: Any,
+    *,
+    expected_count: int,
+) -> list[list[float]] | None:
+    """Return a complete, ordered ``/api/embed`` batch or ``None``.
+
+    Ollama promises one non-empty numeric vector per input, in input order.
+    Validate that contract for the *whole* response before exposing any vector
+    to callers: a partial response, an empty/malformed vector, or inconsistent
+    dimensions must fail closed rather than letting reconciliation write only
+    part of a file.
+    """
+    if not isinstance(data, dict):
+        return None
+    embeddings = data.get("embeddings")
+    if not isinstance(embeddings, list) or len(embeddings) != expected_count:
+        return None
+
+    normalized: list[list[float]] = []
+    dimensions: int | None = None
+    for vector in embeddings:
+        if (
+            not isinstance(vector, list)
+            or not vector
+            or any(
+                isinstance(value, bool) or not isinstance(value, (int, float))
+                for value in vector
+            )
+        ):
+            return None
+        if dimensions is None:
+            dimensions = len(vector)
+        elif len(vector) != dimensions:
+            return None
+        normalized.append([float(value) for value in vector])
+    return normalized
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Roles — the per-endpoint routing that makes misroutes impossible
 # ──────────────────────────────────────────────────────────────────────────
@@ -768,6 +807,85 @@ class OllamaClient:
         # Both endpoints exhausted without a vector.
         raise last_exc or OllamaUnreachable(
             "embed: all endpoints exhausted", role="embed", model=mdl
+        )
+
+    def embed_many(
+        self, texts: list[str], *, model: str | None = None,
+        timeout: float | httpx.Timeout | None = None, retries: int | None = None,
+    ) -> list[list[float]]:
+        """Return one ordered embedding per input using one ``/api/embed`` call.
+
+        The modern Ollama endpoint accepts a list in ``input``. The response is
+        accepted only when its cardinality, vector shapes, and dimensions are
+        valid for the entire batch. Older Ollama versions that return 404 for
+        ``/api/embed`` retain compatibility through the scalar legacy fallback.
+
+        An empty input is a no-op and performs no network request.
+        """
+        if not texts:
+            return []
+
+        mdl = model or config.embeddings.primary.model
+        tmo = timeout if timeout is not None else httpx.Timeout(
+            config.embeddings.primary.timeout_seconds,
+            connect=config.embeddings.primary.connect_timeout_seconds,
+        )
+        try:
+            data = self._request_json(
+                OllamaRole.EMBED,
+                "/api/embed",
+                {"model": mdl, "input": texts},
+                timeout=tmo,
+                retries=retries,
+                model=mdl,
+                op="embed_many",
+            )
+        except OllamaInputError as e:
+            raise EmbeddingInputError(
+                model=mdl,
+                text_len=sum(len(text) for text in texts),
+                ollama_message=str(e),
+            ) from e
+        except OllamaError as e:
+            if e.status_code == 404:
+                return [
+                    self.embed(text, model=mdl, timeout=tmo, retries=retries)
+                    for text in texts
+                ]
+            raise
+
+        embeddings = _extract_embedding_batch(data, expected_count=len(texts))
+        if embeddings is not None:
+            self._embed_ok_once = True
+            return embeddings
+
+        err_msg = data.get("error", "") if isinstance(data, dict) else ""
+        if err_msg and _is_ctx_overflow_message(err_msg):
+            raise EmbeddingContextError(
+                model=mdl,
+                text_len=sum(len(text) for text in texts),
+                ollama_message=err_msg,
+            )
+
+        keys = sorted(data.keys()) if isinstance(data, dict) else []
+        raw_embeddings = data.get("embeddings") if isinstance(data, dict) else None
+        returned_count = len(raw_embeddings) if isinstance(raw_embeddings, list) else None
+        event_logger.warning(json.dumps({
+            "event": "embed_unexpected_shape",
+            "op": "embed_many",
+            "role": "embed",
+            "endpoint": "/api/embed",
+            "model": mdl,
+            "response_keys": keys,
+            "expected_count": len(texts),
+            "returned_count": returned_count,
+        }, sort_keys=True))
+        raise OllamaError(
+            "unexpected embed batch response shape from /api/embed "
+            f"(response_keys={keys}, expected_count={len(texts)}, "
+            f"returned_count={returned_count})",
+            role="embed",
+            model=mdl,
         )
 
     def generate(

--- a/palinode/indexer/reconcile.py
+++ b/palinode/indexer/reconcile.py
@@ -302,40 +302,86 @@ def apply(p: Plan, embedder: Any = _embedder) -> Diff:
             # vector is in hand (or we are deferring embeds entirely).
             embeddings: dict[str, list[float]] = {}
             if not deferred:
-                for pw in p.to_index:
+                use_scalar_fallback = True
+                embed_many = getattr(embedder, "embed_many", None)
+                if p.to_index and callable(embed_many):
                     try:
-                        emb = embedder.embed(pw.section.content)
-                    except EmbeddingInputError as e:
-                        # Per-input failure on a healthy backend (e.g. bge-m3
-                        # NaN vector for this exact string). Aborting the
-                        # whole file here made the note vanish from recall
-                        # entirely — not even FTS. Degrade just this section
-                        # to the FTS-only shape the deferred path already
-                        # writes; the rest of the file indexes normally.
-                        logger.warning(
-                            "embed rejected this input; section written "
-                            "FTS-only op=index file_path=%s section_id=%s "
-                            "text_len=%d error=%r",
-                            state.file_path, pw.section.section_id,
-                            len(pw.section.content), e.ollama_message,
+                        batch = embed_many([
+                            pw.section.content for pw in p.to_index
+                        ])
+                    except EmbeddingInputError:
+                        # A batch rejection proves at least one deterministic
+                        # per-input failure but cannot identify which section.
+                        # Retry individually so only the poisoned section loses
+                        # its vector and healthy sections still index normally.
+                        logger.info(
+                            "batch embed rejected an input; retrying sections "
+                            "individually op=index file_path=%s sections=%d",
+                            state.file_path, len(p.to_index),
                         )
-                        diff.embed_failures += 1
-                        diff.vec_ok = False
-                        continue
                     except EmbeddingUnavailable as e:
-                        # Backend failure, typed at the embedder boundary. The
-                        # watcher/indexer path wants retry-and-continue, not a
-                        # crash: fold it into the same fail-closed abort a
-                        # falsy `[]` used to trigger, so the file is retried
-                        # intact on the next pass.
                         raise _EmbedOutage(
-                            diff.embed_failures + 1, pw.section.section_id
+                            diff.embed_failures + 1,
+                            p.to_index[0].section.section_id,
                         ) from e
-                    if not emb:
-                        raise _EmbedOutage(
-                            diff.embed_failures + 1, pw.section.section_id
+                    else:
+                        valid_batch = (
+                            isinstance(batch, list)
+                            and len(batch) == len(p.to_index)
+                            and all(isinstance(vector, list) and vector for vector in batch)
                         )
-                    embeddings[pw.section.chunk_id] = emb
+                        if not valid_batch:
+                            actual = len(batch) if isinstance(batch, list) else None
+                            logger.warning(
+                                "batch embed returned an invalid response "
+                                "op=index file_path=%s expected=%d actual=%s",
+                                state.file_path, len(p.to_index), actual,
+                            )
+                            raise _EmbedOutage(
+                                diff.embed_failures + 1,
+                                p.to_index[0].section.section_id,
+                            )
+                        embeddings.update({
+                            pw.section.chunk_id: vector
+                            for pw, vector in zip(p.to_index, batch, strict=True)
+                        })
+                        use_scalar_fallback = False
+
+                if use_scalar_fallback:
+                    for pw in p.to_index:
+                        try:
+                            emb = embedder.embed(pw.section.content)
+                        except EmbeddingInputError as e:
+                            # Per-input failure on a healthy backend (e.g. bge-m3
+                            # NaN vector for this exact string). Aborting the
+                            # whole file here made the note vanish from recall
+                            # entirely — not even FTS. Degrade just this section
+                            # to the FTS-only shape the deferred path already
+                            # writes; the rest of the file indexes normally.
+                            logger.warning(
+                                "embed rejected this input; section written "
+                                "FTS-only op=index file_path=%s section_id=%s "
+                                "text_len=%d error=%r",
+                                state.file_path, pw.section.section_id,
+                                len(pw.section.content), e.ollama_message,
+                            )
+                            diff.embed_failures += 1
+                            diff.vec_ok = False
+                            continue
+                        except EmbeddingUnavailable as e:
+                            # Backend failure, typed at the embedder boundary. The
+                            # watcher/indexer path wants retry-and-continue, not a
+                            # crash: fold it into the same fail-closed abort a
+                            # falsy `[]` used to trigger, so the file is retried
+                            # intact on the next pass.
+                            raise _EmbedOutage(
+                                diff.embed_failures + 1, pw.section.section_id
+                            ) from e
+                        if not emb:
+                            raise _EmbedOutage(
+                                diff.embed_failures + 1, pw.section.section_id
+                            )
+                        embeddings[pw.section.chunk_id] = emb
 
             for pw in p.to_index:
                 vec_ok, fts_ok = store.write_chunk_row(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,30 @@ def _warm_embed_gate(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _bridge_scalar_embed_test_doubles(monkeypatch):
+    """Keep existing scalar embed test doubles valid after batching.
+
+    Write-path tests historically replace the public ``embed()`` seam to
+    model success, outage, and partial failure. Production reconciliation now
+    calls ``embed_many()``; when a test replaces ``embed()``, route the batch
+    dynamically through that replacement so the test still exercises its
+    intended condition instead of contacting a developer's Ollama instance.
+    Tests that patch ``embed_many()`` directly override this bridge normally.
+    """
+    from palinode.core import embedder
+
+    original_embed = embedder.embed
+    original_embed_many = embedder.embed_many
+
+    def embed_many(texts):
+        if embedder.embed is not original_embed:
+            return [embedder.embed(text) for text in texts]
+        return original_embed_many(texts)
+
+    monkeypatch.setattr(embedder, "embed_many", embed_many)
+
+
+@pytest.fixture(autouse=True)
 def _isolated_rate_counters(request: pytest.FixtureRequest) -> dict:
     """Clear the process-wide limiter while arming restoration first."""
     from palinode.api import rate_limit

--- a/tests/test_embedder_context_hardening.py
+++ b/tests/test_embedder_context_hardening.py
@@ -26,6 +26,7 @@ import pytest
 from palinode.core import embedder
 from palinode.core.embedder import (
     EmbeddingContextError,
+    EmbeddingInputError,
     EmbeddingUnavailable,
     _is_ctx_overflow_message,
     check_model_context,
@@ -39,6 +40,15 @@ def _client_with_embed(*, embed_return=None, embed_side_effect=None):
         fake.embed.side_effect = embed_side_effect
     else:
         fake.embed.return_value = embed_return
+    return patch("palinode.core.embedder.get_ollama_client", return_value=fake)
+
+
+def _client_with_embed_many(*, embed_return=None, embed_side_effect=None):
+    fake = MagicMock(name="OllamaClient")
+    if embed_side_effect is not None:
+        fake.embed_many.side_effect = embed_side_effect
+    else:
+        fake.embed_many.return_value = embed_return
     return patch("palinode.core.embedder.get_ollama_client", return_value=fake)
 
 
@@ -120,6 +130,33 @@ def test_embed_public_propagates_embedding_unavailable():
             _client_with_embed(embed_side_effect=OllamaUnreachable("offline", role="embed")):
         with pytest.raises(EmbeddingUnavailable):
             embedder.embed("test text")
+
+
+def test_embed_many_public_returns_ordered_batch():
+    expected = [[0.1, 0.2], [0.3, 0.4]]
+    with patch("palinode.core.embedder._run_preflight_once"), \
+            _client_with_embed_many(embed_return=expected):
+        assert embedder.embed_many(["alpha", "beta"]) == expected
+
+
+def test_embed_many_propagates_typed_input_error():
+    error = EmbeddingInputError(
+        model="bge-m3", text_len=9, ollama_message="unsupported value: NaN"
+    )
+    with patch("palinode.core.embedder._run_preflight_once"), \
+            _client_with_embed_many(embed_side_effect=error):
+        with pytest.raises(EmbeddingInputError):
+            embedder.embed_many(["alpha", "beta"])
+
+
+def test_embed_many_wraps_backend_error_with_aggregate_length():
+    error = OllamaUnreachable("offline", role="embed")
+    with patch("palinode.core.embedder._run_preflight_once"), \
+            _client_with_embed_many(embed_side_effect=error):
+        with pytest.raises(EmbeddingUnavailable) as exc_info:
+            embedder.embed_many(["alpha", "beta"])
+    assert exc_info.value.text_len == len("alpha") + len("beta")
+    assert exc_info.value.cause == "offline"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -26,6 +26,7 @@ from palinode.core.ollama_client import (
     CircuitBreaker,
     CircuitState,
     EmbeddingContextError,
+    EmbeddingInputError,
     OllamaCircuitOpen,
     OllamaClient,
     OllamaError,
@@ -503,6 +504,77 @@ def test_embed_unexpected_shape_exhausts_both_then_raises():
     with pytest.raises(OllamaError):
         client.embed("hi")
     assert paths == ["/api/embed", "/api/embeddings"]  # tried both on unexpected shape
+
+
+def test_embed_many_uses_one_ordered_batch_request(monkeypatch):
+    monkeypatch.setattr(config.embeddings.primary, "url", "http://embed-host:11434")
+    requests = []
+
+    def handler(request):
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json={"embeddings": [[1, 2], [3, 4]]})
+
+    client, _, _ = make_client(handler, retries=0)
+    assert client.embed_many(["alpha", "beta"]) == [[1.0, 2.0], [3.0, 4.0]]
+    assert requests == [{"model": config.embeddings.primary.model,
+                         "input": ["alpha", "beta"]}]
+
+
+def test_embed_many_empty_input_performs_no_request():
+    def handler(request):  # pragma: no cover - a request is the failure
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    client, _, _ = make_client(handler, retries=0)
+    assert client.embed_many([]) == []
+
+
+@pytest.mark.parametrize("body", [
+    {"embeddings": [[0.1, 0.2]]},  # partial response
+    {"embeddings": [[0.1, 0.2], []]},
+    {"embeddings": [[0.1, 0.2], ["not-a-number", 0.3]]},
+    {"embeddings": [[0.1, 0.2], [0.3]]},  # inconsistent dimensions
+    {"embedding": [0.1, 0.2]},  # scalar legacy shape is invalid for a batch
+])
+def test_embed_many_rejects_incomplete_or_malformed_whole_response(body):
+    calls = 0
+
+    def handler(request):
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json=body)
+
+    client, _, _ = make_client(handler, retries=0)
+    with pytest.raises(OllamaError, match="unexpected embed batch response shape"):
+        client.embed_many(["alpha", "beta"])
+    assert calls == 1
+
+
+def test_embed_many_context_overflow_reports_aggregate_input_length():
+    def handler(request):
+        return httpx.Response(200, json={"error": "prompt is too long for max context"})
+
+    client, _, _ = make_client(handler, retries=0)
+    with pytest.raises(EmbeddingContextError) as exc_info:
+        client.embed_many(["alpha", "beta"])
+    assert exc_info.value.text_len == len("alpha") + len("beta")
+
+
+def test_embed_many_input_error_is_typed_and_not_retried():
+    calls = 0
+
+    def handler(request):
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            500,
+            text="failed to encode response: json: unsupported value: NaN",
+        )
+
+    client, _, _ = make_client(handler, retries=3)
+    with pytest.raises(EmbeddingInputError) as exc_info:
+        client.embed_many(["alpha", "beta"])
+    assert exc_info.value.text_len == len("alpha") + len("beta")
+    assert calls == 1
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/test_reconcile_batch_embeddings.py
+++ b/tests/test_reconcile_batch_embeddings.py
@@ -1,0 +1,143 @@
+"""Batch-embedding coverage for the real SQLite reconciliation seam."""
+from __future__ import annotations
+
+import pytest
+
+from palinode.core import store
+from palinode.core.config import config
+from palinode.core.embedder import EmbeddingInputError, EmbeddingUnavailable
+from palinode.indexer import reconcile
+
+_VECTOR_A = [0.1] * 1024
+_VECTOR_B = [0.2] * 1024
+
+
+@pytest.fixture()
+def tmp_store(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    monkeypatch.setattr(config, "db_path", str(tmp_path / ".palinode.db"))
+    monkeypatch.setattr(config.git, "auto_commit", False)
+    store.init_db()
+    return tmp_path
+
+
+def _two_section_plan(tmp_store, *, poison_second: bool = False):
+    path = str(tmp_store / "projects" / "batch.md")
+    (tmp_store / "projects").mkdir(exist_ok=True)
+    second = "POISON " if poison_second else "beta "
+    content = (
+        "---\nid: batch-test\ncategory: projects\n---\n\n"
+        f"## Alpha\n\n{'alpha ' * 500}\n\n"
+        f"## Beta\n\n{second * 500}\n"
+    )
+    plan = reconcile.plan(reconcile.derive(path, content))
+    assert len(plan.to_index) == 2
+    return plan
+
+
+def _row_counts() -> tuple[int, int]:
+    db = store.get_db()
+    try:
+        chunks = db.execute("SELECT count(*) FROM chunks").fetchone()[0]
+        vectors = db.execute("SELECT count(*) FROM chunks_vec").fetchone()[0]
+        return chunks, vectors
+    finally:
+        db.close()
+
+
+def test_reconcile_embeds_all_sections_in_one_ordered_call(tmp_store):
+    plan = _two_section_plan(tmp_store)
+
+    class BatchEmbedder:
+        def __init__(self):
+            self.calls = []
+
+        def embed_many(self, texts):
+            self.calls.append(list(texts))
+            return [_VECTOR_A, _VECTOR_B]
+
+        def embed(self, text):  # pragma: no cover - batching must win
+            raise AssertionError("scalar embed should not be called")
+
+    embedder = BatchEmbedder()
+    diff = reconcile.apply(plan, embedder)
+
+    assert diff.committed and diff.written == 2
+    assert embedder.calls == [[pw.section.content for pw in plan.to_index]]
+    assert _row_counts() == (2, 2)
+
+
+@pytest.mark.parametrize("batch", [
+    [_VECTOR_A],
+    [_VECTOR_A, []],
+    [_VECTOR_A, _VECTOR_B, _VECTOR_A],
+])
+def test_reconcile_rejects_partial_or_malformed_batch_before_writes(
+    tmp_store, batch
+):
+    plan = _two_section_plan(tmp_store)
+
+    class InvalidBatchEmbedder:
+        def embed_many(self, texts):
+            return batch
+
+    diff = reconcile.apply(plan, InvalidBatchEmbedder())
+
+    assert not diff.committed
+    assert diff.embed_failures == 1
+    assert _row_counts() == (0, 0)
+
+
+def test_reconcile_batch_outage_rolls_back_the_whole_file(tmp_store):
+    plan = _two_section_plan(tmp_store)
+
+    class OfflineEmbedder:
+        def embed_many(self, texts):
+            raise EmbeddingUnavailable(
+                backend="local",
+                model="bge-m3",
+                text_len=sum(len(text) for text in texts),
+                cause="offline",
+            )
+
+    diff = reconcile.apply(plan, OfflineEmbedder())
+
+    assert not diff.committed
+    assert diff.embed_failures == 1
+    assert _row_counts() == (0, 0)
+
+
+def test_batch_input_error_falls_back_to_isolate_poisoned_section(tmp_store):
+    plan = _two_section_plan(tmp_store, poison_second=True)
+
+    class SelectiveEmbedder:
+        def __init__(self):
+            self.batch_calls = 0
+            self.scalar_calls = []
+
+        def embed_many(self, texts):
+            self.batch_calls += 1
+            raise EmbeddingInputError(
+                model="bge-m3",
+                text_len=sum(len(text) for text in texts),
+                ollama_message="unsupported value: NaN",
+            )
+
+        def embed(self, text):
+            self.scalar_calls.append(text)
+            if "POISON" in text:
+                raise EmbeddingInputError(
+                    model="bge-m3",
+                    text_len=len(text),
+                    ollama_message="unsupported value: NaN",
+                )
+            return _VECTOR_A
+
+    embedder = SelectiveEmbedder()
+    diff = reconcile.apply(plan, embedder)
+
+    assert diff.committed and diff.written == 2
+    assert not diff.vec_ok and diff.embed_failures == 1
+    assert embedder.batch_calls == 1
+    assert embedder.scalar_calls == [pw.section.content for pw in plan.to_index]
+    assert _row_counts() == (2, 1)


### PR DESCRIPTION
Closes #159

## Why

Reconciliation currently pays one sequential HTTP round trip for every section in a file even though Ollama's modern `/api/embed` endpoint accepts an input list. A 30-section file therefore makes 30 requests where one is sufficient.

## What changed

- Add ordered `OllamaClient.embed_many(texts)` and an embedder-level batch boundary.
- Send one `/api/embed` request for every section in `p.to_index`.
- Validate exact response cardinality, non-empty numeric vectors, and consistent dimensions before exposing any vector.
- Preserve compatibility with old Ollama versions through the existing scalar legacy fallback when `/api/embed` returns 404.
- Preserve both load-bearing failure modes:
  - backend failure still becomes `EmbeddingUnavailable` and then `_EmbedOutage`, rolling back the whole file;
  - a deterministic batch input rejection falls back to scalar calls only to identify the poisoned section, which remains FTS-only while healthy sections retain vectors.
- Keep custom scalar-only embedders working and keep existing write-path test doubles isolated from a developer's live Ollama.
- Add real-SQLite regression coverage for ordering, partial/malformed batches, full rollback, and per-input isolation.

Consolidation's separate per-item contradiction check is intentionally unchanged; this PR stays on the issue's requested `p.to_index` scope.

## Performance

Measured against a local Ollama `bge-m3` after one warm-up, using the same 30 generated project-decision sections (30,920 characters total) and alternating scalar/batch order across three runs:

| Path | HTTP requests | Runs (seconds) | Median |
| --- | ---: | --- | ---: |
| Existing scalar loop | 30 | 2.1969, 2.1888, 2.1796 | 2.1888 s |
| Batch | 1 | 1.5393, 1.5383, 1.5399 | 1.5393 s |

That is 30 → 1 requests and a 1.42× median wall-clock speedup on this machine. The input generator used `## Project decision {i}` followed by the same 248-character decision paragraph repeated four times, for `i in range(30)`; each run asserted 30 non-empty outputs.

## Validation

- `pytest -q`: **3,417 passed, 10 skipped, 5 xfailed**
- Focused batch/write-path suite: **110 passed**
- `ruff check palinode/ tests/ scripts/`: passed
- `bandit -r palinode/ -ll`: no medium/high issues
- `git diff --check`: passed

AI assistance disclosure: I used OpenAI Codex to help inspect, implement, and validate this change, and I reviewed the final diff and evidence.
