### PR TITLE
feat(save): report created, resaved, disambiguated, or replaced

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Added
 
+- Save receipts now report a closed `save_outcome` (`created`, `resaved`,
+  `disambiguated`, or `replaced`) plus the original slug when disambiguation
+  occurs. The raw API/JSON response, human CLI, and MCP confirmation all expose
+  the outcome so callers can distinguish new files from rewrites and explicit
+  replacements.
 - `docs/BENCHMARKS.md` row E: the production write path measured on a 100-question stratified
   subset — session-end extraction alone beats raw-transcript reading (E0 0.810 vs 0.750);
   consolidation's ARCHIVE op costs that gain back (E1 0.750) and filtering it via the

--- a/palinode/cli/save.py
+++ b/palinode/cli/save.py
@@ -308,7 +308,21 @@ def save(
             # filesystem path.
             filename = result.get("rel_path") or result.get("file_path", result.get("file", "unknown"))
             id_str = result.get("id", "unknown")
-            console.print(f"[green]Saved:[/green] {filename} (id: {id_str})")
+            save_outcome = result.get("save_outcome")
+            if save_outcome == "disambiguated":
+                original_slug = result.get("disambiguated_from")
+                outcome_text = (
+                    f"disambiguated from {original_slug}"
+                    if original_slug
+                    else "disambiguated"
+                )
+            elif save_outcome in {"created", "resaved", "replaced"}:
+                outcome_text = save_outcome
+            else:
+                # Graceful compatibility with an older API server.
+                outcome_text = None
+            label = f"Saved ({outcome_text})" if outcome_text else "Saved"
+            console.print(f"[green]{label}:[/green] {filename} (id: {id_str})")
             # The file is persisted (and git-committed) regardless of embedding.
             # If the inline embed didn't complete — cold/absent Ollama — say so
             # plainly instead of leaving the user thinking the save half-failed:

--- a/palinode/core/save.py
+++ b/palinode/core/save.py
@@ -293,12 +293,14 @@ def save_memory(
             already pushes explicitly afterward.
 
     Returns:
-        A dict carrying ``file_path``, ``rel_path``, ``id``, the index health
-        flags (``indexed``/``embedded``/``indexed_vec``/``indexed_fts``), and
+        A dict carrying ``file_path``, ``rel_path``, ``id``, ``save_outcome``
+        (one of ``created``, ``resaved``, ``disambiguated``, or ``replaced``),
+        ``disambiguated_from``, the index health flags
+        (``indexed``/``embedded``/``indexed_vec``/``indexed_fts``), and
         ``git_committed`` — plus ``git_error`` (why the auto-commit did not
         land: not a repo, missing identity, lock held), ``index_error``,
-        ``description_pending``, ``summary_pending``, ``write_time_check``
-        and ``forget`` when they apply.
+        ``description_pending``, ``summary_pending``, ``write_time_check`` and
+        ``forget`` when they apply.
 
     Raises:
         SaveValidationError: any input rejection — malformed envelope, unknown
@@ -499,11 +501,30 @@ def save_memory(
     if not is_safe:
         raise SaveValidationError(f"Security scan failed: {reason}")
 
+    original_slug = slug
     file_path = os.path.join(config.palinode_dir, category, f"{slug}.md")
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
     if slug_was_derived:
         slug, file_path = _disambiguate_derived_slug(slug, file_path, content)
+
+    # Classify the save after derived-slug resolution but before the write.
+    # Looking only at the base path would mislabel a repeat save of an existing
+    # suffixed memory as disambiguated; the selected target's prior existence
+    # is what separates a normal re-save from creation at a new suffix.
+    target_existed = os.path.exists(file_path)
+    if slug_was_derived:
+        if target_existed:
+            save_outcome = "resaved"
+        elif slug != original_slug:
+            save_outcome = "disambiguated"
+        else:
+            save_outcome = "created"
+    else:
+        save_outcome = "replaced" if target_existed else "created"
+    disambiguated_from = (
+        original_slug if save_outcome == "disambiguated" else None
+    )
 
     content_hash = hashlib.sha256(content.encode()).hexdigest()
 
@@ -799,8 +820,9 @@ def save_memory(
             logger.warning("reciprocal contradicts back-link skipped: %s", exc)
 
     logger.info(
-        "Saved memory op=save file_path=%s id=%s category=%s git_committed=%s%s",
-        file_path, frontmatter_dict["id"], category, git_committed,
+        "Saved memory op=save file_path=%s id=%s category=%s "
+        "save_outcome=%s git_committed=%s%s",
+        file_path, frontmatter_dict["id"], category, save_outcome, git_committed,
         f" git_error={git_error!r}" if git_error else "",
     )
 
@@ -845,6 +867,8 @@ def save_memory(
         "file_path": file_path,
         "rel_path": to_rel_path(file_path),
         "id": frontmatter_dict["id"],
+        "save_outcome": save_outcome,
+        "disambiguated_from": disambiguated_from,
         "indexed": indexed,
         "embedded": indexed,
         # Per-index health flags. vec/FTS failures are non-fatal

--- a/palinode/mcp.py
+++ b/palinode/mcp.py
@@ -1981,9 +1981,25 @@ async def _tool_save(arguments: dict[str, Any]) -> list[types.TextContent]:
             "git auto-commit failed (file on disk, not versioned)"
             + (f": {reason}" if reason else "")
         )
+    save_outcome = data.get("save_outcome")
+    if save_outcome == "disambiguated":
+        original_slug = data.get("disambiguated_from")
+        outcome_text = (
+            f"disambiguated from {original_slug}"
+            if original_slug
+            else "disambiguated"
+        )
+    elif save_outcome in {"created", "resaved", "replaced"}:
+        outcome_text = save_outcome
+    else:
+        # Graceful compatibility with an older API server.
+        outcome_text = None
+    confirmation = f"Saved to {rel}"
+    if outcome_text:
+        confirmation += f" ({outcome_text})"
     if warnings:
-        return _text(f"Saved to {rel} [warnings: {'; '.join(warnings)}]")
-    return _text(f"Saved to {rel}")
+        confirmation += f" [warnings: {'; '.join(warnings)}]"
+    return _text(confirmation)
 
 
 # ── ingest ────────────────────────────────────────────────────────

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -284,6 +284,38 @@ async def test_dispatch_save_renders_server_rel_path(monkeypatch):
     assert _NO_PALINODE_ABS_PATH not in text
 
 
+@pytest.mark.parametrize(
+    ("save_outcome", "disambiguated_from", "expected"),
+    [
+        ("replaced", None, "Saved to decisions/target.md (replaced)"),
+        (
+            "disambiguated",
+            "target",
+            "Saved to decisions/target.md (disambiguated from target)",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_dispatch_save_reports_outcome(
+    monkeypatch, save_outcome, disambiguated_from, expected
+):
+    async def fake_post(path, json=None, timeout=30.0):
+        return _FakeResponse({
+            "file_path": _NO_PALINODE_ABS_PATH,
+            "rel_path": _NO_PALINODE_REL_PATH,
+            "id": "decisions-target",
+            "save_outcome": save_outcome,
+            "disambiguated_from": disambiguated_from,
+        })
+
+    monkeypatch.setattr(mcp, "_post", fake_post)
+    result = await _dispatch_tool(
+        "palinode_save", {"content": "body", "type": "Decision"}
+    )
+
+    assert result[0].text == expected
+
+
 @pytest.mark.asyncio
 async def test_dispatch_ingest_renders_server_rel_path(monkeypatch):
     async def fake_post(path, json=None, timeout=60.0):

--- a/tests/test_save_derived_slug_collision.py
+++ b/tests/test_save_derived_slug_collision.py
@@ -52,6 +52,17 @@ def test_colliding_derived_slugs_do_not_overwrite(mock_memory_dir):
 
     rel_paths = [r["rel_path"] for r in results]
     assert len(set(rel_paths)) == 3, f"expected 3 distinct paths, got {rel_paths}"
+    original_slug = os.path.splitext(os.path.basename(rel_paths[0]))[0]
+    assert [r["save_outcome"] for r in results] == [
+        "created",
+        "disambiguated",
+        "disambiguated",
+    ]
+    assert [r["disambiguated_from"] for r in results] == [
+        None,
+        original_slug,
+        original_slug,
+    ]
 
     for marker, result in zip(markers, results, strict=True):
         with open(result["file_path"], "r", encoding="utf-8") as fh:
@@ -65,6 +76,10 @@ def test_identical_content_is_not_duplicated(mock_memory_dir):
     second = _save(content)
 
     assert first["rel_path"] == second["rel_path"]
+    assert first["save_outcome"] == "created"
+    assert second["save_outcome"] == "resaved"
+    assert first["disambiguated_from"] is None
+    assert second["disambiguated_from"] is None
     directory = os.path.dirname(first["file_path"])
     assert len(os.listdir(directory)) == 1
 
@@ -82,6 +97,13 @@ def test_resaving_a_suffixed_memory_reuses_its_own_file(mock_memory_dir):
 
     assert second["rel_path"] != first["rel_path"]
     assert again["rel_path"] == second["rel_path"]
+    assert first["save_outcome"] == "created"
+    assert second["save_outcome"] == "disambiguated"
+    assert second["disambiguated_from"] == os.path.splitext(
+        os.path.basename(first["rel_path"])
+    )[0]
+    assert again["save_outcome"] == "resaved"
+    assert again["disambiguated_from"] is None
 
     directory = os.path.dirname(first["file_path"])
     assert sorted(os.listdir(directory)) == sorted(
@@ -98,6 +120,10 @@ def test_explicit_slug_still_overwrites(mock_memory_dir):
     second = _save("second body", slug="pinned-note")
 
     assert first["rel_path"] == second["rel_path"]
+    assert first["save_outcome"] == "created"
+    assert second["save_outcome"] == "replaced"
+    assert first["disambiguated_from"] is None
+    assert second["disambiguated_from"] is None
     with open(second["file_path"], "r", encoding="utf-8") as fh:
         body = fh.read()
     assert "second body" in body

--- a/tests/test_source_surface.py
+++ b/tests/test_source_surface.py
@@ -87,6 +87,41 @@ def test_save_defaults_source_to_cli(mock_memory_dir):
         assert mock_save.call_args[1]["source"] is None
 
 
+@pytest.mark.parametrize(
+    ("save_outcome", "disambiguated_from", "expected"),
+    [
+        ("replaced", None, "Saved (replaced): insights/pinned-note.md"),
+        (
+            "disambiguated",
+            "shared-opening",
+            "Saved (disambiguated from shared-opening): insights/shared-opening-2.md",
+        ),
+    ],
+)
+def test_save_human_output_reports_outcome(
+    save_outcome, disambiguated_from, expected
+):
+    runner = CliRunner()
+    with patch("palinode.cli.save.api_client.save") as mock_save:
+        mock_save.return_value = {
+            "file_path": "/tmp/result.md",
+            "rel_path": (
+                "insights/pinned-note.md"
+                if save_outcome == "replaced"
+                else "insights/shared-opening-2.md"
+            ),
+            "id": "insights-result",
+            "save_outcome": save_outcome,
+            "disambiguated_from": disambiguated_from,
+        }
+        result = runner.invoke(
+            save, ["body", "--type", "Insight", "--format", "text"]
+        )
+
+    assert result.exit_code == 0
+    assert expected in result.output
+
+
 def test_cli_client_sends_source_header():
     """ADR-010: the CLI httpx Client must carry X-Palinode-Source: cli
     so saves without explicit body `source` are still attributed correctly.


### PR DESCRIPTION
## Summary

- classify every save receipt with the closed `save_outcome` set: `created`, `resaved`, `disambiguated`, or `replaced`
- include `disambiguated_from` as the original derived slug only for a newly suffixed save, and `null` otherwise
- expose the outcome through the raw API/JSON response, human CLI confirmation, and MCP confirmation while keeping older API servers compatible
- add real-filesystem coverage for all four outcomes, including re-saving an already-disambiguated suffix, plus CLI and MCP rendering coverage
- document the addition under the existing Unreleased changelog heading

## Design note

The classification happens after derived-slug resolution but before writing. This matters for a repeat save whose content already lives at `slug-2`: the selected target already exists, so the receipt is `resaved`, not `disambiguated`. Explicit slugs remain `created` when new and `replaced` when their target already exists.

## Verification

- `pytest tests/ -q --ignore=tests/integration` — 3287 passed, 9 skipped, 5 xfailed
- focused save/MCP/CLI and relative-path integration tests — 51 passed
- `ruff check palinode/ tests/ scripts/`
- `bandit -r palinode/ -ll` — no medium/high findings
- issue-reference and changelog structure guards — 18 passed

Closes https://github.com/phasespace-labs/palinode/issues/147

Disclosure: I used AI-assisted tooling during development. I manually reviewed the implementation and verified it with the checks above.
