### PR TITLE
Add return annotations to the CLI API adapter

### DIFF
--- a/palinode/cli/_api.py
+++ b/palinode/cli/_api.py
@@ -1,5 +1,6 @@
 import os
 import httpx
+from typing import Any
 from palinode.core.auth import load_api_token
 from palinode.core.config import config
 from palinode.core.defaults import SAVE_SOURCE_HEADER, SESSION_END_TIMEOUT_SECONDS, _SESSION_END_TIMEOUT_SENTINEL
@@ -84,7 +85,7 @@ class PalinodeAPI:
         date_before: str | None = None,
         include_daily: bool | None = None,
         include_telemetry: bool | None = None,
-    ):
+    ) -> list[dict[str, Any]]:
         # ADR-010: forward the full canonical search surface.
         # Non-None params land in the body verbatim; None means "API default".
         payload: dict = {"query": query, "limit": limit}
@@ -134,7 +135,7 @@ class PalinodeAPI:
         epistemic: str | None = None,
         contradicts: list[str] | None = None,
         backed_by: list[str] | None = None,
-    ):
+    ) -> dict[str, Any]:
         # One inclusion rule, shared with MCP via core/write_input.py: a param
         # is sent when it is not None, so an explicitly-empty ``contradicts=[]``
         # reaches the server as the assertion the caller made rather than being
@@ -175,12 +176,12 @@ class PalinodeAPI:
         response.raise_for_status()
         return response.json()
 
-    def get_status(self):
+    def get_status(self) -> dict[str, Any]:
         response = self.client.get("/status")
         response.raise_for_status()
         return response.json()
 
-    def read(self, file_path: str, meta: bool = False):
+    def read(self, file_path: str, meta: bool = False) -> dict[str, Any]:
         """Read a memory file via the API.
 
         Returns ``{file, content, size_bytes, [frontmatter]}``.  When
@@ -193,7 +194,7 @@ class PalinodeAPI:
         response.raise_for_status()
         return response.json()
 
-    def list_files(self, category: str | None = None, core_only: bool | None = None):
+    def list_files(self, category: str | None = None, core_only: bool | None = None) -> list[dict[str, Any]]:
         """List memory files via the API.  ADR-010."""
         params: dict = {}
         if category:
@@ -204,7 +205,7 @@ class PalinodeAPI:
         response.raise_for_status()
         return response.json()
 
-    def lint(self):
+    def lint(self) -> dict[str, Any]:
         """Run the memory lint pass via the API.  ADR-010.
 
         Raises ``RequestError`` if the API is unreachable; the CLI catches
@@ -214,7 +215,7 @@ class PalinodeAPI:
         response.raise_for_status()
         return response.json()
 
-    def review(self, project: str | None = None):
+    def review(self, project: str | None = None) -> dict[str, Any]:
         """Run the advisory project-memory review via the API.
 
         Raises ``RequestError`` if the API is unreachable; the CLI catches
@@ -227,7 +228,7 @@ class PalinodeAPI:
         response.raise_for_status()
         return response.json()
 
-    def list_prompts(self, task: str | None = None):
+    def list_prompts(self, task: str | None = None) -> list[dict[str, Any]]:
         """List stored prompt versions.  ADR-010."""
         params: dict = {}
         if task:
@@ -236,25 +237,25 @@ class PalinodeAPI:
         response.raise_for_status()
         return response.json()
 
-    def get_prompt(self, name: str):
+    def get_prompt(self, name: str) -> dict[str, Any]:
         """Read a specific prompt by name.  ADR-010."""
         response = self.client.get(f"/prompts/{name}")
         response.raise_for_status()
         return response.json()
 
-    def activate_prompt(self, name: str):
+    def activate_prompt(self, name: str) -> dict[str, Any]:
         """Activate a prompt version.  ADR-010."""
         response = self.client.post(f"/prompts/{name}/activate")
         response.raise_for_status()
         return response.json()
 
-    def ingest_inbox(self):
+    def ingest_inbox(self) -> dict[str, str]:
         """Process files in the inbox directory.  ADR-010."""
         response = self.client.post("/ingest", timeout=60.0)
         response.raise_for_status()
         return response.json()
 
-    def ingest_url(self, url: str, name: str | None = None):
+    def ingest_url(self, url: str, name: str | None = None) -> dict[str, str]:
         """Fetch and save a URL as a research reference.  ADR-010."""
         payload: dict = {"url": url}
         if name:
@@ -278,7 +279,7 @@ class PalinodeAPI:
         duration_seconds: int | None = None,
         push: bool | None = None,
         dry_run: bool = False,
-    ):
+    ) -> dict[str, Any]:
         """Capture session outcomes via the API. ADR-010 (the project-slug derivation work
 fields, the session-end hook audit push)."""
         # `is not None`, not truthiness. An empty list means "considered, none
@@ -311,7 +312,7 @@ fields, the session-end hook audit push)."""
         response.raise_for_status()
         return response.json()
 
-    def get_diff(self, days: int = 7, paths: str = None):
+    def get_diff(self, days: int = 7, paths: str = None) -> dict[str, Any]:
         params: dict = {"days": days}
         if paths:
             params["paths"] = paths
@@ -325,7 +326,7 @@ fields, the session-end hook audit push)."""
         dry_run: bool = False,
         nightly: bool = False,
         sources: list[str] | None = None,
-    ):
+    ) -> dict[str, Any]:
         body: dict = {"dry_run": dry_run, "nightly": nightly}
         # Omitted rather than sent as null so the server's default stays the
         # single definition of "which corpus".
@@ -340,7 +341,7 @@ fields, the session-end hook audit push)."""
         file_path: str,
         reason: str | None = None,
         superseded_by: str | None = None,
-    ):
+    ) -> dict[str, Any]:
         payload: dict = {"file_path": file_path}
         if reason is not None:
             payload["reason"] = reason
@@ -350,7 +351,7 @@ fields, the session-end hook audit push)."""
         response.raise_for_status()
         return response.json()
 
-    def archive_expired(self, dry_run: bool = False):
+    def archive_expired(self, dry_run: bool = False) -> dict[str, Any]:
         response = self.client.post("/archive-expired", json={"dry_run": dry_run})
         response.raise_for_status()
         return response.json()
@@ -362,7 +363,7 @@ fields, the session-end hook audit push)."""
         threshold: float | None = None,
         cooldown_hours: int | None = None,
         trigger_id: str | None = None,
-    ):
+    ) -> dict[str, Any]:
         # ADR-010: forward all four canonical params. Defaults live
         # in palinode.core.defaults so the CLI can show them in --help.  We
         # only include them in the body when non-None so the API still
@@ -381,43 +382,43 @@ fields, the session-end hook audit push)."""
         response.raise_for_status()
         return response.json()
 
-    def trigger_list(self):
+    def trigger_list(self) -> list[dict[str, Any]]:
         response = self.client.get("/triggers")
         response.raise_for_status()
         return response.json()
 
-    def trigger_remove(self, trigger_id: str):
+    def trigger_remove(self, trigger_id: str) -> dict[str, str]:
         response = self.client.delete(f"/triggers/{trigger_id}")
         response.raise_for_status()
         return response.json()
 
-    def reindex(self):
+    def reindex(self) -> dict[str, Any]:
         response = self.client.post("/reindex", timeout=600.0)
         response.raise_for_status()
         return response.json()
 
-    def rebuild_fts(self):
+    def rebuild_fts(self) -> dict[str, Any]:
         response = self.client.post("/rebuild-fts", timeout=60.0)
         response.raise_for_status()
         return response.json()
 
-    def split_layers(self):
+    def split_layers(self) -> dict[str, Any]:
         response = self.client.post("/split-layers", timeout=120.0)
         response.raise_for_status()
         return response.json()
 
-    def bootstrap_ids(self):
+    def bootstrap_ids(self) -> dict[str, Any]:
         response = self.client.post("/bootstrap-fact-ids", timeout=120.0)
         response.raise_for_status()
         return response.json()
 
-    def get_history(self, file_path: str, limit: int = 20, detail: str = "summary"):
+    def get_history(self, file_path: str, limit: int = 20, detail: str = "summary") -> dict[str, Any]:
         params: dict = {"limit": limit, "detail": detail}
         response = self.client.get(f"/history/{file_path}", params=params, timeout=10.0)
         response.raise_for_status()
         return response.json()
 
-    def get_entities(self, entity: str = None):
+    def get_entities(self, entity: str = None) -> list[dict[str, Any]] | dict[str, Any]:
         if entity:
             response = self.client.get(f"/entities/{entity}", timeout=10.0)
         else:
@@ -425,7 +426,7 @@ fields, the session-end hook audit push)."""
         response.raise_for_status()
         return response.json()
 
-    def context_prime(self, cwd: str = None, project: str = None):
+    def context_prime(self, cwd: str = None, project: str = None) -> dict[str, Any]:
         payload: dict = {}
         if cwd:
             payload["cwd"] = cwd
@@ -435,7 +436,7 @@ fields, the session-end hook audit push)."""
         response.raise_for_status()
         return response.json()
 
-    def blame(self, file_path: str, search: str = None, claims: bool = False):
+    def blame(self, file_path: str, search: str = None, claims: bool = False) -> dict[str, Any]:
         params: dict = {}
         if search:
             params["search"] = search
@@ -445,12 +446,12 @@ fields, the session-end hook audit push)."""
         response.raise_for_status()
         return response.json()
 
-    def trace(self, file_path: str):
+    def trace(self, file_path: str) -> dict[str, Any]:
         response = self.client.get(f"/trace/{file_path}", timeout=15.0)
         response.raise_for_status()
         return response.json()
 
-    def rollback(self, file_path: str, commit: str = None, dry_run: bool = True):
+    def rollback(self, file_path: str, commit: str = None, dry_run: bool = True) -> dict[str, Any]:
         params: dict = {"file_path": file_path, "dry_run": dry_run}
         if commit:
             params["commit"] = commit
@@ -458,7 +459,7 @@ fields, the session-end hook audit push)."""
         response.raise_for_status()
         return response.json()
 
-    def push(self):
+    def push(self) -> dict[str, Any]:
         response = self.client.post("/push", timeout=60.0)
         response.raise_for_status()
         return response.json()
@@ -468,7 +469,7 @@ fields, the session-end hook audit push)."""
         content: str,
         min_similarity: float | None = None,
         top_k: int | None = None,
-    ):
+    ) -> list[dict[str, Any]]:
         """Find existing files semantically near draft content.
 
         Defaults applied server-side.  Returns the same shape as
@@ -489,7 +490,7 @@ fields, the session-end hook audit push)."""
         broken_link: str,
         min_similarity: float | None = None,
         top_k: int | None = None,
-    ):
+    ) -> list[dict[str, Any]]:
         """Find files semantically near a broken `[[wikilink]]` target."""
         payload: dict = {"broken_link": broken_link}
         if min_similarity is not None:
@@ -505,7 +506,7 @@ fields, the session-end hook audit push)."""
         file_path: str,
         min_similarity: float | None = None,
         top_k: int | None = None,
-    ):
+    ) -> list[dict[str, Any]]:
         """Find semantically related files not already linked to/from file_path."""
         payload: dict = {"file_path": file_path}
         if min_similarity is not None:
@@ -520,7 +521,7 @@ fields, the session-end hook audit push)."""
         self,
         query: str,
         min_similarity: float | None = None,
-    ):
+    ) -> dict[str, Any]:
         """Check whether any wiki page already covers a topic phrase."""
         payload: dict = {"query": query}
         if min_similarity is not None:


### PR DESCRIPTION
Closes #191

Adds return annotations to the 35 unannotated methods in `palinode/cli/_api.py`, following the mapping published in the issue. Each annotation mirrors the return type of the endpoint handler the method calls.

Notes:
- `get_entities` is annotated `list[dict[str, Any]] | dict[str, Any]` since it serves two endpoints depending on whether an entity ref is given.
- Adds `from typing import Any`, which the module previously did not import.

Verification:
- `ruff check palinode/` — clean
- `pytest -m "not slow"` — 3429 passed, 9 skipped, 5 xfailed
