### PR TITLE
fix(api): fail closed when a sibling deactivation fails

### DIFF
--- a/palinode/api/routers/session.py
+++ b/palinode/api/routers/session.py
@@ -13,7 +13,7 @@ import hashlib
 import logging
 import os
 import re
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
@@ -557,30 +557,56 @@ def activate_prompt_api(name: str) -> dict[str, Any]:
         git_tools.write_memory_file(file_path, new_text)
         changed_files.append(file_path)
 
-    # Deactivate all prompts of the same task
-    for filepath in glob.glob(os.path.join(prompts_dir, "*.md")):
+    def _commit_changed() -> None:
+        # One activation toggle = a per-file commit for each prompt actually
+        # changed. Stage only the prompts this toggle rewrote, never a repo-wide
+        # `git add prompts/*.md` sweep. Runs on the way out of a failed
+        # activation too, so a rewrite that already reached disk is not left
+        # uncommitted.
+        if config.git.auto_commit:
+            for fp in changed_files:
+                git_tools.commit_memory_file(
+                    fp,
+                    f"palinode: activate prompt {name} for task={task} [{os.path.basename(fp)}]",
+                )
+
+    def _fail_closed(filepath: str, exc: Exception) -> NoReturn:
+        # Fail closed: the target is never activated once any sibling write has
+        # failed, so one task cannot end up with two active prompts. The task
+        # keeps whatever was active before, or nothing, and the caller retries.
+        _commit_changed()
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Could not deactivate '{os.path.basename(filepath)}', so "
+                f"'{name}' was not activated: {exc}"
+            ),
+        ) from exc
+
+    # Deactivate all prompts of the same task. Sorted so a failure part-way
+    # through leaves the same files rewritten on every platform.
+    for filepath in sorted(glob.glob(os.path.join(prompts_dir, "*.md"))):
+        resolved = os.path.realpath(filepath)
         try:
-            resolved = os.path.realpath(filepath)
             within = os.path.commonpath([_memory_base_dir(), resolved]) == _memory_base_dir()
-            if not within:
-                continue
+        except ValueError:
+            continue
+        if not within:
+            continue
+        try:
             info = _read_prompt_file(resolved)
             if info["task"] == task and resolved != target_path:
                 _set_active(resolved, False)
-        except Exception:
-            pass
+        except Exception as exc:
+            _fail_closed(resolved, exc)
 
-    # Activate target
-    _set_active(target_path, True)
+    # Activate target last. There is no reliable preflight for a write that
+    # fails, so the real failure goes through the same fail-closed path.
+    try:
+        _set_active(target_path, True)
+    except Exception as exc:
+        _fail_closed(target_path, exc)
 
-    # One activation toggle = a per-file commit for each prompt actually changed
-    # stage only the prompts this toggle rewrote, never a repo-wide
-    # `git add prompts/*.md` sweep.
-    if config.git.auto_commit:
-        for fp in changed_files:
-            git_tools.commit_memory_file(
-                fp,
-                f"palinode: activate prompt {name} for task={task} [{os.path.basename(fp)}]",
-            )
+    _commit_changed()
 
     return {"activated": name, "task": task}

--- a/palinode/api/routers/session.py
+++ b/palinode/api/routers/session.py
@@ -578,7 +578,7 @@ def activate_prompt_api(name: str) -> dict[str, Any]:
         raise HTTPException(
             status_code=409,
             detail=(
-                f"Could not deactivate '{os.path.basename(filepath)}', so "
+                f"Could not update '{os.path.basename(filepath)}', so "
                 f"'{name}' was not activated: {exc}"
             ),
         ) from exc

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -227,6 +227,136 @@ def test_activate_prompt_idempotent(mock_memory_dir):
     assert get_resp.json()["active"] is True
 
 
+def _active_names(prompts_dir: str, task: str) -> list[str]:
+    """Read active state straight off disk for every prompt of one task."""
+    names = []
+    for entry in sorted(os.listdir(prompts_dir)):
+        if not entry.endswith(".md"):
+            continue
+        with open(os.path.join(prompts_dir, entry)) as f:
+            fm = yaml.safe_load(f.read().split("---")[1])
+        if fm.get("task") == task and fm.get("active") is True:
+            names.append(entry)
+    return names
+
+
+@pytest.mark.parametrize("failing", ["compaction-a", "compaction-b", "compaction-c"])
+def test_activate_prompt_fails_closed_when_a_sibling_write_fails(
+    mock_memory_dir, monkeypatch, failing
+):
+    """A failed deactivation must not leave two prompts active for one task.
+
+    Parametrised over the first, middle and last sibling, because the loop
+    aborts at a different point in each and the surviving state differs.
+    """
+    prompts_dir = os.path.join(mock_memory_dir, "prompts")
+    _write_prompt(prompts_dir, "compaction-a", task="compaction", active=True)
+    _write_prompt(prompts_dir, "compaction-b", task="compaction", active=False)
+    _write_prompt(prompts_dir, "compaction-c", task="compaction", active=False)
+    _write_prompt(prompts_dir, "compaction-target", task="compaction", active=False)
+
+    real_write = session.git_tools.write_memory_file
+
+    def flaky_write(file_path, text):
+        if os.path.basename(file_path) == f"{failing}.md":
+            raise OSError("disk went away")
+        return real_write(file_path, text)
+
+    monkeypatch.setattr(session.git_tools, "write_memory_file", flaky_write)
+
+    resp = client.post("/prompts/compaction-target/activate")
+
+    assert resp.status_code == 409
+    assert f"{failing}.md" in resp.json()["detail"]
+
+    # The invariant: at most one active prompt for the task. Zero is a valid
+    # outcome when the previously active sibling was deactivated before the
+    # failure, and both states are safe to retry from.
+    assert len(_active_names(prompts_dir, "compaction")) <= 1
+
+    # The target is the thing that must not have been activated.
+    assert "compaction-target.md" not in _active_names(prompts_dir, "compaction")
+
+
+def test_activate_prompt_fails_closed_when_the_target_write_fails(
+    mock_memory_dir, monkeypatch
+):
+    """The target is activated last, and its own write failure fails closed too."""
+    prompts_dir = os.path.join(mock_memory_dir, "prompts")
+    _write_prompt(prompts_dir, "compaction-a", task="compaction", active=True)
+    _write_prompt(prompts_dir, "compaction-target", task="compaction", active=False)
+
+    real_write = session.git_tools.write_memory_file
+
+    def flaky_write(file_path, text):
+        if os.path.basename(file_path) == "compaction-target.md":
+            raise OSError("disk went away")
+        return real_write(file_path, text)
+
+    monkeypatch.setattr(session.git_tools, "write_memory_file", flaky_write)
+
+    resp = client.post("/prompts/compaction-target/activate")
+
+    assert resp.status_code == 409
+    assert "compaction-target.md" in resp.json()["detail"]
+    assert _active_names(prompts_dir, "compaction") == []
+
+
+def test_activate_prompt_commits_partial_writes_before_failing(
+    mock_memory_dir, monkeypatch
+):
+    """_set_active writes immediately, so whatever reached disk still gets committed."""
+    prompts_dir = os.path.join(mock_memory_dir, "prompts")
+    _write_prompt(prompts_dir, "compaction-a", task="compaction", active=True)
+    _write_prompt(prompts_dir, "compaction-b", task="compaction", active=True)
+    _write_prompt(prompts_dir, "compaction-target", task="compaction", active=False)
+
+    real_write = session.git_tools.write_memory_file
+    committed: list[str] = []
+
+    def flaky_write(file_path, text):
+        if os.path.basename(file_path) == "compaction-b.md":
+            raise OSError("disk went away")
+        return real_write(file_path, text)
+
+    monkeypatch.setattr(session.git_tools, "write_memory_file", flaky_write)
+    monkeypatch.setattr(
+        session.git_tools,
+        "commit_memory_file",
+        lambda fp, msg: committed.append(os.path.basename(fp)),
+    )
+    monkeypatch.setattr(config.git, "auto_commit", True)
+
+    resp = client.post("/prompts/compaction-target/activate")
+
+    assert resp.status_code == 409
+    assert committed == ["compaction-a.md"]
+
+
+def test_activate_prompt_leaves_other_tasks_alone_when_it_fails(
+    mock_memory_dir, monkeypatch
+):
+    """A failure in one task must not touch a prompt belonging to another."""
+    prompts_dir = os.path.join(mock_memory_dir, "prompts")
+    _write_prompt(prompts_dir, "compaction-a", task="compaction", active=True)
+    _write_prompt(prompts_dir, "compaction-target", task="compaction", active=False)
+    _write_prompt(prompts_dir, "extraction-v1", task="extraction", active=True)
+
+    real_write = session.git_tools.write_memory_file
+
+    def flaky_write(file_path, text):
+        if os.path.basename(file_path) == "compaction-a.md":
+            raise OSError("disk went away")
+        return real_write(file_path, text)
+
+    monkeypatch.setattr(session.git_tools, "write_memory_file", flaky_write)
+
+    resp = client.post("/prompts/compaction-target/activate")
+
+    assert resp.status_code == 409
+    assert _active_names(prompts_dir, "extraction") == ["extraction-v1.md"]
+
+
 # ── Integration: /list excludes prompts/ ─────────────────────────────────────
 
 def test_list_memory_excludes_prompts_dir(mock_memory_dir):


### PR DESCRIPTION
Fixes #189.

Fail closed, per the call in the issue thread.

`activate_prompt_api` swallowed every exception from the sibling deactivation loop and then activated the target unconditionally, so a sibling that failed to deactivate stayed `active: true` alongside the newly activated target. The endpoint returned 200.

Now any failure in the loop aborts before the target is activated, and returns 409 naming the file that blocked it. The target write is still last and its own failure goes through the same path, since `os.access` is advisory and can disagree with the write.

Two details from your review that the tests pin:

Zero active is an accepted outcome. If the previously active sibling was deactivated before a later one failed, the task ends with nothing active. The assertion is at most one active per task, not exactly one.

Partial writes are committed on the way out. `_set_active` writes immediately while `auto_commit` only ran at the end, so a bare raise left rewritten files uncommitted. `_commit_changed` now runs on both the success and the failure path.

The glob is sorted. Ordering was previously arbitrary, so which files a part-way failure had already rewritten varied by platform.

Tests, in `tests/test_prompts.py`:

- failure on the first, middle and last sibling, parametrised
- failure on the target write itself
- partial writes committed before the raise
- a prompt belonging to another task is untouched when activation fails

All six fail against the unfixed function, returning 200 where they expect 409.

Gates: `ruff check palinode/ tests/ scripts/` clean, `scripts/check-write-choke-point.sh` and `scripts/check-httpx-monopoly.sh` clean, full suite 3493 passed, 16 skipped, 5 xfailed.
