### PR TITLE
feat(bench): make the BM25 arm observable in the abstention sweep

### DIFF
--- a/bench/abstention.py
+++ b/bench/abstention.py
@@ -208,6 +208,10 @@ def summarize_observations(
         },
         "no_answer_by_kind": by_kind,
         "controls": controls,
+        # Results that reached the merged set through BM25 alone. Zero in the
+        # vector arm by construction, and the number that says whether the
+        # hybrid arm added anything at this floor.
+        "fts_only_results": sum(row.get("fts_only_count") or 0 for row in observations),
         "false_positive_scores": {
             "fused": _score_stats(
                 [
@@ -229,6 +233,11 @@ def summarize_observations(
 
 def _matches_topic(result: dict[str, Any], expected_topic: str) -> bool:
     return expected_topic.casefold() in str(result.get("content", "")).casefold()
+
+
+def _result_key(result: dict[str, Any]) -> str:
+    """The identity the ranker fuses and dedups on."""
+    return f"{result['file_path']}#{result.get('section_id', 'root')}"
 
 
 def _observation(case: QueryCase, results: list[dict[str, Any]]) -> dict[str, Any]:
@@ -267,6 +276,14 @@ def _observation(case: QueryCase, results: list[dict[str, Any]]) -> dict[str, An
         else None,
         "true_match_rank": true_match_rank,
         "best_true_raw_score": best_true_raw_score,
+        # What the arms actually returned, in order. The counted metrics above
+        # are blind to a reordering, so without these the vector and hybrid
+        # rows are identical whenever BM25 changes rank but not membership.
+        "result_keys": [_result_key(result) for result in results],
+        # rank_hybrid attaches raw_score only to candidates the vector arm
+        # produced, so a result without one reached the merged set through
+        # BM25 alone.
+        "fts_only_count": sum(1 for result in results if result.get("raw_score") is None),
     }
 
 
@@ -300,6 +317,90 @@ def _measure(
     }
 
 
+def _fts_candidate_stats(
+    cases: Sequence[QueryCase], *, top_k: int
+) -> dict[str, Any]:
+    """The BM25 candidate scores the per-arm floor is applied to.
+
+    ``search_fts`` normalizes BM25 as ``min(abs(rank) / 25.0, 1.0)``, a scale
+    with no relation to the cosine similarity the vector arm is scored on.
+    One threshold is applied to both, so this records where BM25 actually
+    lands on that shared axis.
+    """
+    from palinode.core import store
+
+    scores: list[float] = []
+    cases_with_candidates = 0
+    for case in cases:
+        rows = store.search_fts(case.query, top_k=top_k * 2)
+        if not rows:
+            continue
+        cases_with_candidates += 1
+        scores.extend(float(row.get("score", 0.0)) for row in rows)
+    return {
+        "cases": len(cases),
+        "cases_with_candidates": cases_with_candidates,
+        "candidates": len(scores),
+        "score_stats": _score_stats(scores),
+    }
+
+
+def compare_arms(
+    vector_measurement: dict[str, Any], hybrid_measurement: dict[str, Any]
+) -> dict[str, Any]:
+    """How the hybrid arm differs from the vector arm at one floor.
+
+    The counted metrics cannot see this. Two arms that return the same number
+    of results for every case, with the same control hits, produce identical
+    summary rows whether BM25 changed the ordering or was dropped entirely.
+    """
+    vector_rows = {row["case_id"]: row for row in vector_measurement["observations"]}
+    hybrid_rows = {row["case_id"]: row for row in hybrid_measurement["observations"]}
+    shared = sorted(vector_rows.keys() & hybrid_rows.keys())
+
+    differing = 0
+    reordered = 0
+    membership_changed = 0
+    for case_id in shared:
+        vector_keys = vector_rows[case_id]["result_keys"]
+        hybrid_keys = hybrid_rows[case_id]["result_keys"]
+        if vector_keys == hybrid_keys:
+            continue
+        differing += 1
+        if set(vector_keys) == set(hybrid_keys):
+            reordered += 1
+        else:
+            membership_changed += 1
+
+    return {
+        "threshold": vector_measurement["threshold"],
+        "cases": len(shared),
+        "cases_differing": differing,
+        "cases_reordered_only": reordered,
+        "cases_membership_changed": membership_changed,
+        "fts_only_results": hybrid_measurement["summary"]["fts_only_results"],
+    }
+
+
+def _arm_comparisons(
+    measurements: Sequence[dict[str, Any]], thresholds: Sequence[float]
+) -> list[dict[str, Any]]:
+    comparisons = []
+    for threshold in thresholds:
+        vector_measurement = next(
+            row
+            for row in measurements
+            if row["mode"] == "vector" and row["threshold"] == threshold
+        )
+        hybrid_measurement = next(
+            row
+            for row in measurements
+            if row["mode"] == "hybrid" and row["threshold"] == threshold
+        )
+        comparisons.append(compare_arms(vector_measurement, hybrid_measurement))
+    return comparisons
+
+
 def _aggregate(
     runs: Sequence[dict[str, Any]], thresholds: Sequence[float]
 ) -> list[dict[str, Any]]:
@@ -322,6 +423,33 @@ def _aggregate(
                     "summary": summarize_observations(observations),
                 }
             )
+    return aggregate
+
+
+def _aggregate_arm_comparisons(
+    runs: Sequence[dict[str, Any]], thresholds: Sequence[float]
+) -> list[dict[str, Any]]:
+    """Sum the per-seed arm comparisons at each floor."""
+    aggregate = []
+    for threshold in thresholds:
+        rows = [
+            row
+            for run in runs
+            for row in run["arm_comparison"]
+            if row["threshold"] == threshold
+        ]
+        aggregate.append(
+            {
+                "threshold": threshold,
+                "cases": sum(row["cases"] for row in rows),
+                "cases_differing": sum(row["cases_differing"] for row in rows),
+                "cases_reordered_only": sum(row["cases_reordered_only"] for row in rows),
+                "cases_membership_changed": sum(
+                    row["cases_membership_changed"] for row in rows
+                ),
+                "fts_only_results": sum(row["fts_only_results"] for row in rows),
+            }
+        )
     return aggregate
 
 
@@ -404,6 +532,8 @@ def evaluate(
                     "num_files": generated.num_files,
                     "num_chunks": indexed.num_facts,
                     "measurements": measurements,
+                    "arm_comparison": _arm_comparisons(measurements, thresholds),
+                    "fts_candidates": _fts_candidate_stats(cases, top_k=top_k),
                 }
             )
 
@@ -429,6 +559,7 @@ def evaluate(
         "runs": runs,
     }
     results["aggregate"] = _aggregate(runs, thresholds)
+    results["arm_comparison"] = _aggregate_arm_comparisons(runs, thresholds)
     return results
 
 
@@ -491,6 +622,52 @@ def render_markdown(results: dict[str, Any]) -> str:
                 f"| {_format_score_stats(summary['false_positive_scores']['raw'])} |"
             )
         lines.extend(["", "Scores describe only false-positive result sets.", ""])
+
+    lines.extend(
+        [
+            "## BM25 arm contribution",
+            "",
+            "The two arms are scored on different axes and share one floor: real cosine "
+            "similarity for the vector arm, `min(abs(bm25) / 25.0, 1.0)` for BM25. This "
+            "table is what separates the arms; the counted metrics above cannot, because "
+            "they are blind to a reordering.",
+            "",
+            "| Threshold | Cases where hybrid differs from vector | Reordered only | Membership changed | Results from BM25 alone |",
+            "|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in results.get("arm_comparison", []):
+        lines.append(
+            f"| {row['threshold']:.2f} "
+            f"| {row['cases_differing']}/{row['cases']} "
+            f"| {row['cases_reordered_only']} "
+            f"| {row['cases_membership_changed']} "
+            f"| {row['fts_only_results']} |"
+        )
+
+    runs_with_candidates = [
+        run for run in results.get("runs", []) if run.get("fts_candidates")
+    ]
+    if runs_with_candidates:
+        lines.extend(
+            [
+                "",
+                "Normalized BM25 candidate scores per seed, before any floor is applied "
+                "(min / median / max):",
+                "",
+                "| Seed | Queries with a BM25 candidate | Candidates | Score min / median / max |",
+                "|---:|---:|---:|---:|",
+            ]
+        )
+        for run in runs_with_candidates:
+            candidates = run["fts_candidates"]
+            lines.append(
+                f"| {run['seed']} "
+                f"| {candidates['cases_with_candidates']}/{candidates['cases']} "
+                f"| {candidates['candidates']} "
+                f"| {_format_score_stats(candidates['score_stats'])} |"
+            )
+        lines.append("")
 
     return "\n".join(lines)
 

--- a/tests/test_bench_abstention.py
+++ b/tests/test_bench_abstention.py
@@ -97,6 +97,83 @@ def test_summarize_counts_queries_and_score_ranges():
     }
 
 
+def test_summary_counts_results_reached_through_bm25_alone():
+    """A merged result with no raw cosine came from the FTS arm."""
+    observations = [
+        {"kind": "absent_natural", "returned_count": 2, "top_score": 1.0,
+         "top_raw_score": 0.42, "true_match": None, "fts_only_count": 1},
+        {"kind": "control_exact", "returned_count": 1, "top_score": 1.0,
+         "top_raw_score": 0.91, "true_match": True, "fts_only_count": 0},
+    ]
+
+    assert abstention.summarize_observations(observations)["fts_only_results"] == 1
+
+
+def test_summary_tolerates_observations_without_arm_provenance():
+    observations = [
+        {"kind": "absent_natural", "returned_count": 0, "top_score": None,
+         "top_raw_score": None, "true_match": None},
+    ]
+
+    assert abstention.summarize_observations(observations)["fts_only_results"] == 0
+
+
+def _measurement(mode, threshold, rows, fts_only=0):
+    return {
+        "mode": mode,
+        "threshold": threshold,
+        "summary": {"fts_only_results": fts_only},
+        "observations": [
+            {"case_id": case_id, "result_keys": keys} for case_id, keys in rows
+        ],
+    }
+
+
+def test_compare_arms_separates_a_reorder_from_a_membership_change():
+    """The counted metrics cannot see either; this is the point of the table."""
+    vector = _measurement(
+        "vector",
+        0.40,
+        [
+            ("same", ["a#1", "b#1"]),
+            ("reordered", ["a#1", "b#1"]),
+            ("membership", ["a#1", "b#1"]),
+        ],
+    )
+    hybrid = _measurement(
+        "hybrid",
+        0.40,
+        [
+            ("same", ["a#1", "b#1"]),
+            ("reordered", ["b#1", "a#1"]),
+            ("membership", ["a#1", "c#1"]),
+        ],
+        fts_only=1,
+    )
+
+    comparison = abstention.compare_arms(vector, hybrid)
+
+    assert comparison == {
+        "threshold": 0.40,
+        "cases": 3,
+        "cases_differing": 2,
+        "cases_reordered_only": 1,
+        "cases_membership_changed": 1,
+        "fts_only_results": 1,
+    }
+
+
+def test_compare_arms_reports_no_difference_when_bm25_changes_nothing():
+    rows = [("only", ["a#1"])]
+    comparison = abstention.compare_arms(
+        _measurement("vector", 0.50, rows), _measurement("hybrid", 0.50, rows)
+    )
+
+    assert comparison["cases_differing"] == 0
+    assert comparison["cases_reordered_only"] == 0
+    assert comparison["cases_membership_changed"] == 0
+
+
 def test_evaluate_runs_real_store_and_preserves_controls(monkeypatch):
     """The evaluation uses real SQLite while the embedder is deterministic."""
     from palinode.core.config import config
@@ -152,8 +229,15 @@ def test_evaluate_runs_real_store_and_preserves_controls(monkeypatch):
     assert vector_summaries[0.5]["controls"]["exact"]["true_hits"] == 1
     assert vector_summaries[0.5]["controls"]["paraphrase"]["true_hits"] == 1
 
+    arm_rows = {row["threshold"]: row for row in results["arm_comparison"]}
+    assert set(arm_rows) == {0.0, 0.5}
+    assert arm_rows[0.5]["cases"] == 3
+    assert results["runs"][0]["fts_candidates"]["cases"] == 3
+
     report = abstention.render_markdown(results)
     report.encode("ascii")
     assert "# Palinode abstention evaluation" in report
     assert "No-answer queries returning a hit" in report
     assert "Production defaults changed: **no**" in report
+    assert "## BM25 arm contribution" in report
+    assert "Results from BM25 alone" in report


### PR DESCRIPTION
Toward #154. Measurement only: no production default changes, no search behaviour changes.

The abstention sweep runs both arms but reports them through counts that cannot see an
ordering change, so `vector` and `hybrid` produced identical rows even where BM25 changed
every result set. This adds the missing observation.

- `_observation` records the ordered result keys and how many results reached the merged set
  through BM25 alone. `rank_hybrid` attaches `raw_score` only to vector candidates, so a
  result without one came from the FTS arm.
- `compare_arms` diffs the two arms at one floor and separates a reorder from a membership
  change.
- `_fts_candidate_stats` records the normalized BM25 scores the shared floor is applied to.
- The Markdown report gains a "BM25 arm contribution" section.

What it showed on the pinned set, 3 seeds, in the issue thread: normalized BM25 tops out at
0.425, so any floor at or above 0.45 empties the FTS list before RRF and hybrid search
becomes vector search. `api_threshold` is 0.5.

## Tests

Four new cases, including the reorder-versus-membership distinction. Inverting that branch
fails the test.

```
ruff check palinode/ tests/ scripts/    clean
pytest -m "not slow"                    3494 passed, 16 skipped, 5 xfailed
```
