### PR TITLE
fix: keep example config defaults aligned

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- `palinode.config.yaml.example` now keeps every documented scalar value aligned with
+  its corresponding dataclass default, except for the explicitly documented schedule
+  and database-path representations. New installs that copy the example therefore use
+  the measured `api_threshold` of 0.5 and the current default result limit of 15.
+
 ### Removed
 
 ### Security

--- a/palinode.config.yaml.example
+++ b/palinode.config.yaml.example
@@ -131,9 +131,9 @@ search:
   # Default threshold for MCP server searches (lower = more results)
   mcp_threshold: 0.4
   # Default threshold for FastAPI searches (higher = more precision)
-  api_threshold: 0.6
+  api_threshold: 0.5
   # Default number of results
-  default_limit: 10
+  default_limit: 15
   # Status values to exclude from search results
   exclude_status:
     - "archived"

--- a/tests/test_example_config_values_match_defaults.py
+++ b/tests/test_example_config_values_match_defaults.py
@@ -1,0 +1,61 @@
+"""Keep the shipped example config aligned with the code defaults."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import yaml
+
+from palinode.core.config import Config
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_CONFIG = REPO_ROOT / "palinode.config.yaml.example"
+
+_ALLOWED_DIFFERENCES = {
+    # Informational only: the actual consolidation schedule lives in crontab.
+    ("consolidation", "schedule"): ("0 11 * * 0", "0 3 * * 0"),
+    # None is a sentinel resolved to <memory_dir>/.palinode.db by load_config().
+    ("db_path",): (".palinode.db", None),
+}
+
+
+def _scalar_leaves(
+    value: object, path: tuple[str, ...] = ()
+) -> Iterator[tuple[tuple[str, ...], object]]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from _scalar_leaves(child, (*path, key))
+        return
+    yield path, value
+
+
+def _value_at_path(value: object, path: tuple[str, ...]) -> object:
+    for part in path:
+        if isinstance(value, dict):
+            value = value[part]
+        else:
+            value = getattr(value, part)
+    return value
+
+
+def test_example_config_scalar_values_match_defaults() -> None:
+    raw = yaml.safe_load(EXAMPLE_CONFIG.read_text(encoding="utf-8")) or {}
+    defaults = Config()
+
+    differences = {
+        path: (example_value, default_value)
+        for path, example_value in _scalar_leaves(raw)
+        if example_value != (default_value := _value_at_path(defaults, path))
+    }
+    unexpected = {
+        path: values
+        for path, values in differences.items()
+        if _ALLOWED_DIFFERENCES.get(path) != values
+    }
+    stale_allowlist = sorted(set(_ALLOWED_DIFFERENCES) - set(differences))
+
+    assert not unexpected and not stale_allowlist, (
+        "palinode.config.yaml.example differs from Config defaults; "
+        f"unexpected={unexpected}, stale_allowlist={stale_allowlist}"
+    )


### PR DESCRIPTION
## Why

The shipped example had drifted from the runtime defaults for `search.api_threshold` and `search.default_limit`. That makes copied configurations behave differently from an otherwise equivalent default installation.

## What changed

- align those two example values with the dataclass defaults
- add a recursive scalar-leaf parity test for the complete example
- narrowly document and allow the two intentional differences:
  - `consolidation.schedule` is informational because the installed crontab owns the actual schedule
  - `db_path` uses a relative sentinel that resolves to the same default file
- add the fix to the Unreleased changelog

The new test was run against the pre-fix example first and failed only for the two values reported in #200. It passes after the example update, so future undocumented drift will be caught.

## Validation

- focused config parity tests: 2 passed
- full test suite: 3728 passed, 16 skipped, 5 xfailed
- `ruff check palinode/ tests/ scripts/`
- `bandit -r palinode/ -ll`
- `git diff --check`

Closes #200
