### PR TITLE
fix(parity): declare surface realizations instead of drift

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -27,6 +27,22 @@ When you add a parameter, add it to all three surfaces (modulo exemptions below)
 
 When the surface is fixed, **remove the `known_drift` entry**. The parity test fails loudly if drift was tracked and the param now exists — that's the test telling you to close the issue.
 
+### Drift or realization
+
+A surface that does not expose a canonical param is not automatically lagging. Two mechanisms sit side by side on `Operation`, and picking the wrong one puts a false statement in the registry:
+
+| | `known_drift` | `surface_realizations` |
+|---|---|---|
+| Says | the surface should expose this and does not, yet | the surface exposes this as its own capability |
+| Value | the GitHub issue tracking the fix | the capability that realizes it, in the identifier form for that surface |
+| Lifetime | temporary; removed when the surface is fixed | permanent; the arrangement is the design |
+| Parity test | xfails, naming the issue | passes, naming the capability |
+| Inventory guard | unaffected | counts the named capability as registered, so it needs no `INVENTORY_BACKLOG` row |
+
+The test question is whether there is anything to fix. `depends` is the worked example: the API realizes the canonical `unblocked` boolean as `GET /depends/_unblocked` rather than as a query param on `GET /depends/{slug}`, and the CLI and MCP call that route. Nothing is lagging, so no issue number can ever be right for it, and it is declared as `surface_realizations[("api", "unblocked")] = "GET /depends/_unblocked"`.
+
+`test_surface_realizations_name_a_real_param_and_capability` checks both halves of every declaration: the param exists in `canonical_params`, and the capability is live on that surface. A declaration nothing verifies rots — the entry this replaced carried an issue number from a private tracker, which resolved in the public one to an unrelated closed issue, and the parity test reported that number for months.
+
 ## Admin-exempt operations
 
 These operations are **not** required to appear on every surface. They are intentionally CLI-only or CLI+API only because they're operational, not memory-semantic.
@@ -118,13 +134,15 @@ If a surface adds sugar, document it here.
 1. **Exempt surface?** Skipped (per `Operation.exempt_surfaces`).
 2. **Plugin?** Skipped on the Python side (Python can't introspect the TypeBox schemas). The TS-side test at `plugin/test/parity.test.ts` enforces plugin parity using the JSON dump produced by `scripts/dump-parity-registry.py`. Run with `cd plugin && npm test`.
 3. **In `known_drift`?** xfailed with `reason="drift tracked in #<issue>"`. The test passes; the issue tracks the fix.
-4. **Otherwise:** asserted present. Missing → CI red.
+4. **In `surface_realizations`?** Passed, naming the capability that realizes the param. Not drift, so not reported as drift.
+5. **Otherwise:** asserted present. Missing → CI red.
 
 The test additionally enforces:
 
 - `test_admin_exempt_ops_are_not_in_registry` — the two lists are disjoint.
 - `test_default_keys_resolve` — every `default_key` reference in the registry exists in `palinode/core/defaults.py`.
 - `test_known_drift_references_a_canonical_param` — `known_drift` keys must reference real canonical param names (catches dangling drift entries after a refactor).
+- `test_surface_realizations_name_a_real_param_and_capability` — `surface_realizations` keys must reference real canonical param names, and each value must name a capability that is live on that surface.
 
 ## Inventory completeness — the surface→registry direction
 
@@ -136,6 +154,8 @@ The param checks above walk `REGISTRY` and verify each surface (registry→surfa
 2. **`INVENTORY_INFRA`** (`palinode/core/parity.py`) — framework/admin/observability surface that is *not* a memory operation: Swagger/Redoc/OpenAPI, the HTML inspector under `/ui`, liveness probes, and the DB-maintenance + importer endpoints (the surface-identifier form of `ADMIN_EXEMPT_OPERATIONS`).
 3. **`INVENTORY_BACKLOG`** (`palinode/core/parity.py`) — a memory-semantic operation that already ships on the surface but has **not yet** been promoted into `REGISTRY` with canonical params. Each entry maps to its tracking issue (the ADR-010 implementation backlog), and alternate names annotate the canonical entry instead of counting as additional capabilities. These are acknowledged, not silently ignored.
 
+A capability named by `surface_realizations` counts as registered under (1): the operation declares that this is how the surface realizes one of its canonical params, so it is part of the registered contract rather than a backlog row awaiting promotion.
+
 A live capability in none of the three buckets **fails the guard** — that is an operation that skipped the contract. Stale buckets also fail (`test_inventory_accounting_is_not_stale`): an entry whose capability was renamed or removed must be cleaned up, mirroring the `known_drift` hygiene rule. `test_inventory_buckets_are_disjoint` keeps each capability classified exactly once.
 
 **Promoting a backlog op into the registry:** add its `Operation` (with canonical params) to `REGISTRY` and remove its `INVENTORY_BACKLOG` entry. The disjoint check fails if you register it without removing the backlog row — that is the test telling you the move is complete.
@@ -146,7 +166,7 @@ Identifier form per surface: MCP = tool name (`palinode_search`); API = `METHOD 
 
 These memory-semantic operations ship on all of MCP/API/CLI today but are not yet promoted into `REGISTRY` with canonical params. They are tracked in the internal registration backlog (admin/framework surface is in `INVENTORY_INFRA`, not here):
 
-`dedup_suggest`, `diff`, `entities`, `history`, `ingest`/`ingest-url`, `lint`, `orphan_repair`, `prompt` (list/show/activate), `push`, `session_end`, and the trigger `list`/`remove` + `check-triggers` + `search-associative` API endpoints. `depends/_unblocked` is tracked under #97.
+`dedup_suggest`, `diff`, `entities`, `history`, `ingest`/`ingest-url`, `lint`, `orphan_repair`, `prompt` (list/show/activate), `push`, `session_end`, and the trigger `list`/`remove` + `check-triggers` + `search-associative` API endpoints.
 
 Promoting each (registry `Operation` + canonical params + removing its backlog entry) is the per-op work the issue tracks; this contract makes the gap explicit and prevents *new* unregistered ops from slipping in alongside them.
 
@@ -169,7 +189,9 @@ inventory; this document does not duplicate temporary exceptions.
 ## Known drift
 
 `Operation.known_drift` in `palinode/core/parity.py` is the only drift
-inventory. Do not copy its entries into a hand-maintained table here: that
+inventory. It records surfaces that are lagging, not surfaces that differ by
+design — for those see `surface_realizations` and the table under "Drift or
+realization" above. Do not copy its entries into a hand-maintained table here: that
 second list cannot participate in either parity guard and will drift from the
 registry again.
 

--- a/palinode/core/parity.py
+++ b/palinode/core/parity.py
@@ -22,6 +22,13 @@ mirror to the others.  When surfaces drift, record the drift
 in ``known_drift`` with the GitHub issue number — the test xfails the
 drift entry until the issue closes.
 
+Not every difference is drift.  When a surface realizes a canonical param as
+a separate capability — a sibling route rather than a query param, say — that
+is a permanent, correct arrangement, and ``known_drift`` is the wrong home for
+it: there is no issue to close.  Record it in ``surface_realizations`` instead,
+naming the capability that realizes it.  The parity test passes on those
+entries and the inventory guard counts the named capability as registered.
+
 Admin-only operations (reindex, migrations, doctor, etc.) are explicitly
 exempt from parity by listing them in ``ADMIN_EXEMPT_OPERATIONS``.  The
 contract is "all memory operations are equivalent across surfaces, by
@@ -92,6 +99,16 @@ class Operation:
     #: with the issue ref — once the issue closes and the surface is fixed,
     #: remove the entry and the test enforces.
     known_drift: dict[tuple[Surface, str], int] = field(default_factory=dict)
+    #: Permanent per-surface realizations, keyed by ``(surface, param_name)``.
+    #: Value is the surface identifier of the capability that realizes the
+    #: param — ``"METHOD /path"`` for the API, the tool name for MCP, the
+    #: command path for the CLI.  Contrast with ``known_drift`` directly above:
+    #: drift is TEMPORARY, tracked by an issue, and removed when the surface is
+    #: fixed; a realization is PERMANENT, names a capability, and has no issue
+    #: because there is nothing to fix.  The parity test passes on these keys
+    #: rather than xfailing, and ``registered_capabilities`` counts the named
+    #: capability as registered, so it needs no ``INVENTORY_BACKLOG`` row.
+    surface_realizations: dict[tuple[Surface, str], str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -581,11 +598,10 @@ REGISTRY: tuple[Operation, ...] = (
         known_drift={},
     ),
     # ── depends ────────────────────────────────────────────────────────
-    # The `unblocked` mode is exposed as a separate REST endpoint
-    # (GET /depends/_unblocked) rather than a query param on
-    # GET /depends/{slug}, so it does not appear in the API endpoint's
-    # function signature.  Recorded as known drift to keep the parity test
-    # from failing; the endpoint exists but under a different URL.
+    # The API realizes `unblocked` as its own route, GET /depends/_unblocked,
+    # rather than as a query param on GET /depends/{slug}.  The CLI and MCP
+    # take a boolean and call that route.  This is the shipped design, not a
+    # lag, so it is declared as a surface realization rather than as drift.
     Operation(
         name="depends",
         canonical_params=(
@@ -596,8 +612,9 @@ REGISTRY: tuple[Operation, ...] = (
         mcp_tool="palinode_depends",
         api_endpoint=("GET", "/depends/{slug:path}"),
         plugin_tool="palinode_depends",
-        known_drift={
-            ("api", "unblocked"): 97,
+        known_drift={},
+        surface_realizations={
+            ("api", "unblocked"): "GET /depends/_unblocked",
         },
     ),
 )
@@ -740,7 +757,6 @@ INVENTORY_BACKLOG: dict[Surface, dict[str, int | InventoryBacklogEntry]] = {
     "api": {
         "DELETE /triggers/{trigger_id}": 170,
         "GET /triggers": 170,
-        "GET /depends/_unblocked": 97,
         "GET /diff": 170,
         "GET /entities": 170,
         "GET /entities/{entity_ref:path}": 170,
@@ -799,6 +815,13 @@ def registered_capabilities(surface: Surface) -> frozenset[str]:
             ids.add(f"{method} {path}")
         elif surface == "cli" and op.cli_command is not None:
             ids.add(op.cli_command)
+        # A param realized as its own capability on this surface is part of the
+        # registered contract too — that is what the declaration says.  Without
+        # this the inventory guard would report the realizing capability as
+        # unaccounted for and it would need a backlog row it does not deserve.
+        for (realized_surface, _param), capability in op.surface_realizations.items():
+            if realized_surface == surface:
+                ids.add(capability)
     return frozenset(ids)
 
 

--- a/plugin/test/parity.test.ts
+++ b/plugin/test/parity.test.ts
@@ -10,6 +10,12 @@
  * param), the matching ``known_drift`` entry must be removed — this test
  * fails loudly when that hasn't happened, which is exactly the point.
  *
+ * ``surface_realizations`` is the other way a param can legitimately be
+ * absent: the surface exposes it as its own capability rather than as a
+ * parameter, permanently, so there is no issue to close.  No plugin entry
+ * exists today; the handling is here so the two suites keep reading the
+ * registry the same way if one is ever added.
+ *
  * The registry is loaded from ``plugin/parity-registry.json``, regenerated
  * before each ``npm test`` run by the ``pretest`` script invoking
  * ``scripts/dump-parity-registry.py``.  No checked-in artifact; the
@@ -54,6 +60,12 @@ interface DriftEntry {
   issue: number;
 }
 
+interface RealizationEntry {
+  surface: Surface;
+  param: string;
+  capability: string;
+}
+
 interface RegistryOperation {
   name: string;
   canonical_params: CanonicalParam[];
@@ -63,6 +75,7 @@ interface RegistryOperation {
   plugin_tool: string | null;
   exempt_surfaces: Surface[];
   known_drift: DriftEntry[];
+  surface_realizations: RealizationEntry[];
 }
 
 interface ParityRegistry {
@@ -172,6 +185,25 @@ describe("ADR-010 plugin parity", () => {
     }
     expect(bad).toEqual([]);
   });
+
+  it("surface_realizations entries reference real canonical params", () => {
+    // Mirrors the param half of
+    // test_surface_realizations_name_a_real_param_and_capability.  The
+    // capability half is Python-side: only that suite can introspect the
+    // live surfaces a realization can name.
+    const bad: string[] = [];
+    for (const op of registry.operations) {
+      const canonicalNames = new Set(op.canonical_params.map((cp) => cp.name));
+      for (const realization of op.surface_realizations ?? []) {
+        if (!canonicalNames.has(realization.param)) {
+          bad.push(
+            `${op.name}: surface_realizations[("${realization.surface}", "${realization.param}")]`,
+          );
+        }
+      }
+    }
+    expect(bad).toEqual([]);
+  });
 });
 
 // Build the case list at module scope so vitest can render one test per
@@ -180,6 +212,7 @@ function buildCases(): Array<{
   op: RegistryOperation;
   param: CanonicalParam;
   driftIssue: number | null;
+  realizedBy: string | null;
 }> {
   // Need to load the registry synchronously here (before beforeAll runs)
   // for vitest to enumerate test names at collection time.
@@ -188,6 +221,7 @@ function buildCases(): Array<{
     op: RegistryOperation;
     param: CanonicalParam;
     driftIssue: number | null;
+    realizedBy: string | null;
   }> = [];
   for (const op of reg.operations) {
     if (!op.plugin_tool) continue; // Only ops that target the plugin.
@@ -196,10 +230,14 @@ function buildCases(): Array<{
       const drift = op.known_drift.find(
         (d) => d.surface === "plugin" && d.param === param.name,
       );
+      const realization = (op.surface_realizations ?? []).find(
+        (r) => r.surface === "plugin" && r.param === param.name,
+      );
       cases.push({
         op,
         param,
         driftIssue: drift ? drift.issue : null,
+        realizedBy: realization ? realization.capability : null,
       });
     }
   }
@@ -218,7 +256,7 @@ describe("ADR-010 plugin canonical params", () => {
     return;
   }
 
-  for (const { op, param, driftIssue } of cases) {
+  for (const { op, param, driftIssue, realizedBy } of cases) {
     const caseId = `${op.name}/plugin/${param.name}`;
     it(caseId, () => {
       const tool = pluginTools.get(op.plugin_tool!);
@@ -236,6 +274,11 @@ describe("ADR-010 plugin canonical params", () => {
           );
         }
         // Drift is current and the param is missing as expected — passes.
+        return;
+      }
+
+      if (realizedBy !== null) {
+        // Not drift: the plugin exposes this param as its own capability.
         return;
       }
 

--- a/scripts/dump-parity-registry.py
+++ b/scripts/dump-parity-registry.py
@@ -47,7 +47,7 @@ def _canonical_param_to_dict(cp: Any) -> dict[str, Any]:
 
 
 def _operation_to_dict(op: Any) -> dict[str, Any]:
-    """Serialize an Operation including known_drift, normalized for JSON."""
+    """Serialize an Operation including its drift and realization entries."""
     drift_entries = sorted(
         (
             {
@@ -56,6 +56,17 @@ def _operation_to_dict(op: Any) -> dict[str, Any]:
                 "issue": issue,
             }
             for (surface, param_name), issue in op.known_drift.items()
+        ),
+        key=lambda d: (d["surface"], d["param"]),
+    )
+    realization_entries = sorted(
+        (
+            {
+                "surface": surface,
+                "param": param_name,
+                "capability": capability,
+            }
+            for (surface, param_name), capability in op.surface_realizations.items()
         ),
         key=lambda d: (d["surface"], d["param"]),
     )
@@ -68,6 +79,7 @@ def _operation_to_dict(op: Any) -> dict[str, Any]:
         "plugin_tool": op.plugin_tool,
         "exempt_surfaces": sorted(op.exempt_surfaces),
         "known_drift": drift_entries,
+        "surface_realizations": realization_entries,
     }
 
 

--- a/tests/test_depends.py
+++ b/tests/test_depends.py
@@ -5,6 +5,7 @@ Covers:
 - traverse_depends: empty deps, chains, unblocked/blocked, orphans
 - find_unblocked: returns only items ready to start
 - CLI: palinode depends command (via CLI runner with patched api_client methods)
+- API: the two routes, and that the sibling route stays a sibling
 
 All tests use tmp_path with real markdown files — no mocking of the filesystem.
 """
@@ -270,3 +271,70 @@ def test_cli_depends_no_args_error():
     result = runner.invoke(cli_main, ["depends"])
 
     assert result.exit_code != 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# API: GET /depends/{slug:path} and its sibling GET /depends/_unblocked
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# The registry declares the sibling route as how the ``api`` surface realizes
+# the canonical ``unblocked`` param (``surface_realizations`` in
+# ``palinode/core/parity.py``).  These pin the two response shapes so that
+# declaration keeps describing something true.
+
+
+def _api_client(tmp_path, monkeypatch):
+    import importlib
+
+    from fastapi.testclient import TestClient
+
+    from palinode.core.config import config
+
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    monkeypatch.setattr(config, "db_path", str(tmp_path / ".palinode.db"))
+    for _k in ("PALINODE_API_TOKEN", "PALINODE_API_TOKEN_FILE", "PALINODE_API_HOST"):
+        monkeypatch.delenv(_k, raising=False)
+    # The memory files below are written before the API starts, so the
+    # startup guard would otherwise read a populated dir with no database as a
+    # misconfiguration and refuse to serve.  Here the fresh DB is the point.
+    monkeypatch.setenv("PALINODE_ALLOW_FRESH_DB", "1")
+    import palinode.api.server as srv
+
+    srv = importlib.reload(srv)
+    srv._rate_counters.clear()
+    return TestClient(srv.app, raise_server_exceptions=True)
+
+
+def test_api_unblocked_route_returns_a_list(tmp_path, monkeypatch):
+    """``GET /depends/_unblocked`` answers with the ready list, not a slug view.
+
+    Declared before ``GET /depends/{slug:path}`` in the router, so a reorder
+    would make ``_unblocked`` match as a slug and return a dict.  That is the
+    failure this pins: the assertion is on the shape, not just the status.
+    """
+    _write_md(tmp_path, "a.md", {"slug": "milestone/A", "status": "in_progress"})
+
+    with _api_client(tmp_path, monkeypatch) as client:
+        response = client.get("/depends/_unblocked")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert isinstance(body, list)
+    assert [item["slug"] for item in body] == ["milestone/A"]
+    assert set(body[0]) == {"slug", "status", "file_path"}
+
+
+def test_api_depends_route_returns_the_neighbourhood(tmp_path, monkeypatch):
+    """``GET /depends/{slug}`` answers with the dict view for one slug."""
+    _write_md(tmp_path, "a.md", {"slug": "milestone/A", "status": "done"})
+    _write_md(tmp_path, "b.md", {"slug": "milestone/B", "depends_on": ["milestone/A"]})
+
+    with _api_client(tmp_path, monkeypatch) as client:
+        response = client.get("/depends/milestone/B")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert isinstance(body, dict)
+    assert body["slug"] == "milestone/B"
+    assert body["unblocked"] is True
+    assert [dep["slug"] for dep in body["depends_on"]] == ["milestone/A"]

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -12,6 +12,11 @@ reported as ``xfail`` with a ``reason="drift tracked in #N"`` — the test
 ``known_drift`` entry must be removed (or the test will fail because the
 parameter now appears unexpectedly).
 
+A param a surface realizes as its own capability is a different thing, and is
+declared in ``surface_realizations``.  Those cases *pass*, naming the realizing
+capability: the arrangement is permanent, so reporting it as drift would say
+something untrue and point a reader at an issue that is never going to close.
+
 The parametrized checks in this Python module intentionally skip the plugin:
 Python cannot introspect the TypeBox schemas in ``plugin/index.ts``.  Plugin
 parameter parity is enforced separately by ``plugin/test/parity.test.ts``,
@@ -366,6 +371,15 @@ def test_canonical_param_present(case: tuple[Operation, Surface, CanonicalParam]
             )
         pytest.xfail(f"drift tracked in #{issue}")
 
+    realization = op.surface_realizations.get(drift_key)
+    if realization is not None:
+        # Not drift: the surface exposes this param as its own capability.
+        # The declaration is checked for truth by
+        # test_surface_realizations_name_a_real_param_and_capability, so there
+        # is nothing left to assert here beyond recording what realizes it.
+        print(f"{op.name}/{surface}: {cp.name!r} realized as {realization}")
+        return
+
     assert cp.name in surface_params, (
         f"{op.name}/{surface}: canonical param {cp.name!r} not exposed "
         f"(found: {sorted(surface_params)}). "
@@ -488,6 +502,33 @@ def test_known_drift_references_a_canonical_param() -> None:
                 bad.append(f"{op.name}: known_drift[({surface!r}, {param_name!r})]")
     assert not bad, (
         "known_drift entries reference unknown params:\n  "
+        + "\n  ".join(bad)
+    )
+
+
+def test_surface_realizations_name_a_real_param_and_capability() -> None:
+    """``surface_realizations`` must name a real param and a live capability.
+
+    Both halves matter.  The first entry in this registry rotted precisely
+    because nothing checked it: it carried an issue number from a private
+    tracker that resolved, in the public one, to an unrelated closed issue, and
+    the parity test reported that number for months.  A declaration nothing
+    verifies is a comment with a data structure's punctuation.
+    """
+    bad: list[str] = []
+    for op in REGISTRY:
+        canonical_names = {cp.name for cp in op.canonical_params}
+        for (surface, param_name), capability in op.surface_realizations.items():
+            key = f"{op.name}: surface_realizations[({surface!r}, {param_name!r})]"
+            if param_name not in canonical_names:
+                bad.append(f"{key} names no canonical param")
+            if surface not in _LIVE_CAPABILITIES:
+                bad.append(f"{key} targets surface {surface!r}, which is not introspectable")
+                continue
+            if capability not in _LIVE_CAPABILITIES[surface]():
+                bad.append(f"{key} = {capability!r} is not present on {surface}")
+    assert not bad, (
+        "surface_realizations entries do not describe reality:\n  "
         + "\n  ".join(bad)
     )
 


### PR DESCRIPTION
Closes #196.

All three `97` references are gone: the `known_drift` value, the `INVENTORY_BACKLOG` row, and the sentence in `docs/PARITY.md`. The number was from the private tracker and resolved, here, to a closed issue about the embedder.

Built to the shape you specified in the issue thread.

`surface_realizations` on `Operation`, keyed by `(surface, param_name)`, valued with the realizing capability. `depends` declares `("api", "unblocked"): "GET /depends/_unblocked"`. Its docstring sits directly under `known_drift` and contrasts with it line by line: temporary and tracked by an issue, against permanent and naming a capability.

The parity test passes rather than xfails on those keys, and prints the realizing capability. `test_canonical_param_present[depends/api/unblocked]` now reports PASSED. The suite has no xfails left in it.

The inventory guard counts a declared realization as registered. `registered_capabilities()` adds the named capability for the surface, so `GET /depends/_unblocked` is accounted for by the registry rather than by a backlog row, and the row is deleted in the same commit.

There is a guard test, and it checks both halves. `test_surface_realizations_name_a_real_param_and_capability` asserts each key names a real canonical param and each value names a capability live on that surface. I mutated both halves to confirm it bites: a wrong route fails the guard plus `test_no_unregistered_capabilities[api]`, and a misspelled param fails the guard plus the acceptance test.

`docs/PARITY.md` gains a "Drift or realization" table with `depends` as the worked example, a fourth step in the how-the-test-reads-parity list, and the new guard in the enforced-tests list. The false sentence is deleted.

Two things beyond the five bullets, both drop-able if you would rather they went separately.

`scripts/dump-parity-registry.py` serializes the field, and `plugin/test/parity.test.ts` reads it: the param-half guard mirrored, and a plugin realization treated as a pass in `buildCases`. No plugin entry exists today. Without this the TypeScript suite is blind to a field the registry can carry, which is close to how the first entry rotted.

Two API tests in `tests/test_depends.py`. Nothing pinned either route's response shape, and the registry now asserts the sibling route exists. The `_unblocked` test asserts a list back with `{slug, status, file_path}` keys, not just a 200: the route is declared before `/depends/{slug:path}`, so a reorder makes `_unblocked` match as a slug and return a dict. I swapped the two route definitions to check the test fails on that, and it does.

Behaviour is unchanged on all three surfaces.

Local: 3655 passed, 15 skipped, 0 xfailed. `ruff check palinode/ tests/ scripts/` clean, `bandit -r palinode/ -ll` clean, `npm test` 71 passed, `tsc --noEmit` clean.

`docs/PARITY.md` also touched by #173. My edits are the step-4 subsection, the reads-parity list, the enforced-tests list, the inventory paragraph, the drift section, and one deleted sentence at line 149; the locator hunks in #173 do not overlap.
