### PR TITLE
fix(diagnostics): remove private issue refs in checks and add AST guard

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **Diagnostic check results no longer cite unfollowable private issue references ([#205](https://github.com/phasespace-labs/palinode/issues/205)).**
+  `git_commit_ready`, `memory_dir_exists`, and `recall_write_health` carried bare `#NNN`
+  references in their `linked_issue` fields (and in `recall_write_health`'s remediation
+  message) that either pointed at non-existent numbers or resolved to unrelated public
+  issues. These have been cleared to `None` and the remediation message updated. A new
+  AST-based test guard (`test_no_issue_refs_in_diagnostics_strings`) prevents bare issue
+  numbers from being reintroduced into string literals across `palinode/diagnostics/`.
+
 ### Removed
 
 ### Security

--- a/palinode/diagnostics/checks/git_identity.py
+++ b/palinode/diagnostics/checks/git_identity.py
@@ -52,7 +52,6 @@ def git_commit_ready(ctx: DoctorContext) -> CheckResult:
             severity="info",
             passed=True,
             message="git.auto_commit is disabled; saves are not git-versioned.",
-            linked_issue="#1025",
         )
 
     memory_dir = str(Path(ctx.config.memory_dir).expanduser().resolve())
@@ -66,7 +65,6 @@ def git_commit_ready(ctx: DoctorContext) -> CheckResult:
             passed=False,
             message="git binary not found; auto-commit cannot run.",
             remediation="Install git, or set git.auto_commit: false in palinode.config.yaml.",
-            linked_issue="#1025",
         )
     except subprocess.TimeoutExpired:
         return CheckResult(
@@ -74,7 +72,6 @@ def git_commit_ready(ctx: DoctorContext) -> CheckResult:
             severity="info",
             passed=True,
             message="git rev-parse timed out in memory_dir; skipping identity check.",
-            linked_issue="#1025",
         )
 
     if repo.returncode != 0 or repo.stdout.strip() != "true":
@@ -90,7 +87,6 @@ def git_commit_ready(ctx: DoctorContext) -> CheckResult:
                 f"Run 'git -C {memory_dir} init' (and set user.name / user.email) "
                 "so saves are versioned, or set git.auto_commit: false."
             ),
-            linked_issue="#1025",
         )
 
     # ``git var GIT_COMMITTER_IDENT`` applies exactly the predicate ``git
@@ -117,7 +113,6 @@ def git_commit_ready(ctx: DoctorContext) -> CheckResult:
                 f"'git -C {memory_dir} config user.email \"palinode@localhost\"' "
                 "(or set them globally for the service user)."
             ),
-            linked_issue="#1025",
         )
 
     return CheckResult(
@@ -125,5 +120,4 @@ def git_commit_ready(ctx: DoctorContext) -> CheckResult:
         severity="warn",
         passed=True,
         message=f"memory_dir is a git repository with a commit identity: {memory_dir}",
-        linked_issue="#1025",
     )

--- a/palinode/diagnostics/checks/memory_dir.py
+++ b/palinode/diagnostics/checks/memory_dir.py
@@ -24,7 +24,6 @@ def memory_dir_exists(ctx: DoctorContext) -> CheckResult:
             passed=True,
             message=f"Memory directory exists: {memory_dir}",
             remediation=None,
-            linked_issue="#190",
         )
 
     return CheckResult(
@@ -36,5 +35,4 @@ def memory_dir_exists(ctx: DoctorContext) -> CheckResult:
             f"Create the directory or set PALINODE_DIR to an existing path.\n"
             f"  mkdir -p {memory_dir}"
         ),
-        linked_issue="#190",
     )

--- a/palinode/diagnostics/checks/recall_write_health.py
+++ b/palinode/diagnostics/checks/recall_write_health.py
@@ -33,8 +33,6 @@ from pathlib import Path
 from palinode.diagnostics.registry import register
 from palinode.diagnostics.types import CheckResult, DoctorContext
 
-_LINKED_ISSUE = "#371"
-
 
 @register(tags=("fast",))
 def recall_write_health(ctx: DoctorContext) -> CheckResult:
@@ -48,7 +46,6 @@ def recall_write_health(ctx: DoctorContext) -> CheckResult:
             passed=True,
             message="DB file does not exist — skipping recall-write health check.",
             remediation=None,
-            linked_issue=_LINKED_ISSUE,
         )
 
     try:
@@ -63,7 +60,6 @@ def recall_write_health(ctx: DoctorContext) -> CheckResult:
                 "Verify db_path in config and that palinode-api has been started "
                 "at least once to create the DB."
             ),
-            linked_issue=_LINKED_ISSUE,
         )
 
     try:
@@ -89,7 +85,6 @@ def recall_write_health(ctx: DoctorContext) -> CheckResult:
                 "yet initialised. Start palinode-api once to create the schema."
             ),
             remediation=None,
-            linked_issue=_LINKED_ISSUE,
         )
     finally:
         con.close()
@@ -104,7 +99,6 @@ def recall_write_health(ctx: DoctorContext) -> CheckResult:
             passed=True,
             message="DB has no chunks yet — nothing to recall.",
             remediation=None,
-            linked_issue=_LINKED_ISSUE,
         )
 
     if max_recall == 0 and recalled_rows == 0:
@@ -123,9 +117,8 @@ def recall_write_health(ctx: DoctorContext) -> CheckResult:
                 "  palinode search 'any topic you have memories about'\n"
                 "  palinode doctor\n"
                 "If recall_count is still 0 after a search that returned hits, "
-                "the store write-back is broken (see #371)."
+                "the store write-back is broken."
             ),
-            linked_issue=_LINKED_ISSUE,
         )
 
     # ADR-007 §6.6 importance-spread signal. Recall metadata is being written;
@@ -156,5 +149,4 @@ def recall_write_health(ctx: DoctorContext) -> CheckResult:
             f"chunks recalled, MAX(recall_count)={max_recall}." + spread
         ),
         remediation=None,
-        linked_issue=_LINKED_ISSUE,
     )

--- a/tests/test_diagnostics_skeleton.py
+++ b/tests/test_diagnostics_skeleton.py
@@ -65,14 +65,14 @@ class TestMemoryDirExistsPass:
 
         assert result.remediation is None
 
-    def test_linked_issue_present_on_pass(self, tmp_path: Path) -> None:
+    def test_linked_issue_is_none_on_pass(self, tmp_path: Path) -> None:
         memory_dir = tmp_path / "palinode"
         memory_dir.mkdir()
 
         ctx = _ctx(memory_dir)
         result = run_one(ctx, "memory_dir_exists")
 
-        assert result.linked_issue == "#190"
+        assert result.linked_issue is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_no_issue_refs_user_surface.py
+++ b/tests/test_no_issue_refs_user_surface.py
@@ -294,6 +294,46 @@ def test_no_issue_refs_in_ci_workflows() -> None:
     )
 
 
+def _string_constant_refs_in(path: Path) -> list[tuple[int, str]]:
+    """(line, ref_text) for every string constant in *path* carrying an issue ref."""
+    import ast
+
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:  # pragma: no cover — a broken file fails elsewhere
+        return []
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if _issue_refs(node.value):
+                found.append((getattr(node, "lineno", 1), node.value))
+    return found
+
+
+def test_no_issue_refs_in_diagnostics_strings() -> None:
+    """String constants in ``palinode/diagnostics/`` must not carry bare issue refs.
+
+    Scoped strictly to ``palinode/diagnostics/``: diagnostic check results and
+    remediation messages are surfaced directly to the user during health
+    checks, so unfollowable private issue references in string constants or
+    check-linked issues mislead users or link to unrelated issues on the public
+    tracker.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    offenders: list[str] = []
+    diag_root = repo_root / "palinode" / "diagnostics"
+    for py in sorted(diag_root.rglob("*.py")):
+        for line, text in _string_constant_refs_in(py):
+            rel = py.relative_to(repo_root)
+            offenders.append(f"  {rel}:{line}: {_issue_refs(text)}  →  {text.strip()[:70]}")
+
+    assert not offenders, (
+        "Unfollowable issue refs found in diagnostics string constants. A bare "
+        "number cannot be followed by a public reader — use the full public issue "
+        "URL, or name the change instead:\n" + "\n".join(offenders)
+    )
+
+
 # ── What counts as an unfollowable reference ─────────────────────────────────
 # The guards above are only as good as this distinction, and it is the part a
 # contributor actually collides with, so it is pinned directly.


### PR DESCRIPTION
Fixes https://github.com/phasespace-labs/palinode/issues/205

### Summary of Changes
- Cleaned up 10 bare `#NNN` issue references across `git_identity.py`, `memory_dir.py`, and `recall_write_health.py` (including module constant and remediation text).
- Added AST test guard `test_no_issue_refs_in_diagnostics_strings` in `tests/test_no_issue_refs_user_surface.py` scoped to `palinode/diagnostics/`.
- Added changelog entry under `## Unreleased` > `### Fixed` in `docs/CHANGELOG.md`.

### Verification
- Verified test guard fails before fix and passes after.
- All unit & changelog tests passed (66/66 passed).
- `ruff check` and `bandit` passed with zero errors.